### PR TITLE
Fix: Added ELB permissions to cloud-bench

### DIFF
--- a/solutions/CloudBench/CloudBench.yaml
+++ b/solutions/CloudBench/CloudBench.yaml
@@ -67,6 +67,7 @@ Resources:
                   - "ec2:CreateNetworkInterface"
                   - "ec2:DeleteNetworkInterface"
                   - "ec2:Describe*"
+                  - "elasticloadbalancing:DescribeLoadBalancers"
                   - "events:PutRule"
                   - "events:PutTargets"
                   - "iam:DeleteAccessKey"


### PR DESCRIPTION
Added missing permissions to run CIS AWS benchmarks. 