### PR TITLE
fix: don't specify RoleName so long stack names work

### DIFF
--- a/templates/CloudBench.yaml
+++ b/templates/CloudBench.yaml
@@ -38,7 +38,6 @@ Resources:
   TaskRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-TaskRole"
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -105,7 +104,6 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-ExecutionRole"
       AssumeRolePolicyDocument:
         Statement:
         - Effect: Allow

--- a/templates/CloudConnector.yaml
+++ b/templates/CloudConnector.yaml
@@ -35,7 +35,6 @@ Resources:
   TaskRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-TaskRole"
       AssumeRolePolicyDocument:
         Statement:
         - Effect: Allow
@@ -67,7 +66,6 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-ExecutionRole"
       AssumeRolePolicyDocument:
         Statement:
         - Effect: Allow


### PR DESCRIPTION
When using custom attributes to set names for resources, it can happen that the generated name exceeds the 64 character limit. There are a couple of roles using this pattern, potentially causing deployment issues (just hit the problem on the first test, with stack name "airadier-test-from-cli").

By not specyfing the _fooName_ attribute, AWS will generate a name based on the Stack or SubStack name + an identifier, and truncate as necessary to keep under the limits.

This PR removes the RoleName for 4 resources that were causing this issue