### PR TITLE
chore: make the build execution less verbose

### DIFF
--- a/templates/ECSImageScanning.yaml
+++ b/templates/ECSImageScanning.yaml
@@ -176,7 +176,7 @@ Resources:
             build:
               commands:
               - |
-                  python - <<EOF
+                  cat > app.py <<EOF
                   import boto3
                   import json
                   import os
@@ -255,3 +255,4 @@ Resources:
                   if __name__ == "__main__":
                       main()
                   EOF
+              - python app.py


### PR DESCRIPTION
Executing python directly from the stdin and using the <<EOF would repeat the full executed command,
including all the code block, over and over again just to notify that the command was executed,
it failed, etc.

Write to an app.py file first, so the failing command can be just "python app.py"