### PR TITLE
Cloud-Bench: Adds support for both agent access key and API token

### DIFF
--- a/templates/CloudBench.yaml
+++ b/templates/CloudBench.yaml
@@ -21,6 +21,9 @@ Parameters:
   SysdigSecureAPITokenSsm:
     Type: AWS::SSM::Parameter::Name
     Description: "Name of the parameter in SSM containing the Sysdig Secure API Token"
+  SysdigAgentKeySsm:
+    Type: AWS::SSM::Parameter::Name
+    Description: "Name of the parameter in SSM containing the Sysdig Agent Key"
   S3ConfigBucket:
     Type: String
     Description: Name of a bucket (must exist) where the configuration YAML files will be stored
@@ -127,6 +130,7 @@ Resources:
               Resource:
                 - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureEndpointSsm}
                 - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureAPITokenSsm}
+                - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigAgentKeySsm}
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -181,6 +185,8 @@ Resources:
               ValueFrom: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureEndpointSsm}
             - Name: SECURE_API_TOKEN
               ValueFrom: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureAPITokenSsm}
+            - Name: AGENT_KEY
+              ValueFrom: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigAgentKeySsm}
           Image: sysdiglabs/cloud-bench:master
           Essential: true
           PortMappings:

--- a/templates/CloudVision.yaml
+++ b/templates/CloudVision.yaml
@@ -9,6 +9,7 @@ Metadata:
         Parameters:
           - SysdigSecureEndpoint
           - SysdigSecureAPIToken
+          - SysdigAgentKey
 
       - Label:
           default: "Modules to Deploy"
@@ -30,6 +31,8 @@ Metadata:
         default: "Sysdig Secure Endpoint"
       SysdigSecureAPIToken:
         default: "Sysdig Secure API Token"
+      SysdigAgentKey:
+        default: "Sysdig Agent Key"
       CloudBenchDeploy:
         default: "Do you want to deploy Cloud Security Posture Management / Compliance?"
       CloudConnectorDeploy:
@@ -87,6 +90,9 @@ Parameters:
     Default: ""
     Description: Leave it blank to let us to deploy the infrastructure required for running Sysdig for Cloud
 
+  SysdigAgentKey:
+    Type: String
+    NoEcho: true
   SysdigSecureAPIToken:
     Type: String
     NoEcho: true
@@ -122,6 +128,13 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
+
+  SysdigAgentKeyParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: "Sysdig Agent Key"
+      Type: String
+      Value: !Ref SysdigAgentKey
 
   SysdigSecureAPITokenParameter:
     Type: AWS::SSM::Parameter
@@ -185,4 +198,5 @@ Resources:
         Subnets: !If [ DeployNewECSCluster, !GetAtt [ "ECSFargateClusterStack", "Outputs.PrivateSubnets" ], !Join [ ",", !Ref ExistentECSClusterPrivateSubnets ] ]
         SysdigSecureEndpointSsm: !Ref SysdigSecureEndpointParameter
         SysdigSecureAPITokenSsm: !Ref SysdigSecureAPITokenParameter
+        SysdigAgentKeySsm: !Ref SysdigAgentKeyParameter
         S3ConfigBucket: !Ref S3ConfigBucket


### PR DESCRIPTION
This is so that cloud-bench can work with either agent access keys or API token. But first preference is going to be agent access keys.