### PR TITLE
feat: automatic VerifySSL parameter depending on URL

### DIFF
--- a/templates/CloudBench.yaml
+++ b/templates/CloudBench.yaml
@@ -24,7 +24,15 @@ Parameters:
   S3ConfigBucket:
     Type: String
     Description: Name of a bucket (must exist) where the configuration YAML files will be stored
+  VerifySSL:
+    Type: String
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Default: "Yes"
 
+Conditions:
+  VerifySSL: !Equals [!Ref VerifySSL, "Yes"]
 
 Resources:
   LogGroup:
@@ -173,6 +181,9 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "ecs"
         - Name: CloudBench
+          Environment:
+            - Name: VERIFY_SSL
+              Value: !If [ VerifySSL, "true", "false" ]
           DependsOn:
             - ContainerName: Config
               Condition: SUCCESS

--- a/templates/CloudConnector.yaml
+++ b/templates/CloudConnector.yaml
@@ -24,6 +24,15 @@ Parameters:
   S3ConfigBucket:
     Type: String
     Description: Name of a bucket (must exist) where the configuration YAML files will be stored
+  VerifySSL:
+    Type: String
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Default: "Yes"
+
+Conditions:
+  VerifySSL: !Equals [!Ref VerifySSL, "Yes"]
 
 Resources:
   LogGroup:
@@ -158,6 +167,9 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "ecs"
         - Name: CloudConnector
+          Environment:
+            - Name: VERIFY_SSL
+              Value: !If [ VerifySSL, "true", "false" ]
           Secrets:
             - Name: SECURE_URL
               ValueFrom: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureEndpointSsm}

--- a/templates/CloudVision.yaml
+++ b/templates/CloudVision.yaml
@@ -115,6 +115,17 @@ Conditions:
          - !Condition DeployCloudBench
        - !Condition RequiresNewECSCluster
   DeployECSImageScanning: !Equals [!Ref ECSImageScanningDeploy, "Yes"]
+  EndpointIsSaas:
+    Fn::Or:
+      - Fn::Equals:
+        - !Ref SysdigSecureEndpoint
+        - "https://secure.sysdig.com"
+      - Fn::Equals:
+        - !Ref SysdigSecureEndpoint
+        - "https://eu1.app.sysdig.com/secure"
+      - Fn::Equals:
+        - !Ref SysdigSecureEndpoint
+        - "https://us2.app.sysdig.com/secure"
 
 Resources:
   S3ConfigBucket:
@@ -145,6 +156,7 @@ Resources:
       Parameters:
         SysdigSecureEndpointSsm: !Ref SysdigSecureEndpointParameter
         SysdigSecureAPITokenSsm: !Ref SysdigSecureAPITokenParameter
+        VerifySSL: !If [ EndpointIsSaas, "Yes", "No" ]
 
   ECSImageScanningStack:
     Type: AWS::CloudFormation::Stack
@@ -154,6 +166,7 @@ Resources:
       Parameters:
         SysdigSecureEndpointSsm: !Ref SysdigSecureEndpointParameter
         SysdigSecureAPITokenSsm: !Ref SysdigSecureAPITokenParameter
+        VerifySSL: !If [ EndpointIsSaas, "Yes", "No" ]
 
   ECSFargateClusterStack:
     Type: AWS::CloudFormation::Stack
@@ -173,6 +186,7 @@ Resources:
         SysdigSecureEndpointSsm: !Ref SysdigSecureEndpointParameter
         SysdigSecureAPITokenSsm: !Ref SysdigSecureAPITokenParameter
         S3ConfigBucket: !Ref S3ConfigBucket
+        VerifySSL: !If [ EndpointIsSaas, "Yes", "No" ]
 
   CloudBenchStack:
     Type: AWS::CloudFormation::Stack
@@ -186,3 +200,4 @@ Resources:
         SysdigSecureEndpointSsm: !Ref SysdigSecureEndpointParameter
         SysdigSecureAPITokenSsm: !Ref SysdigSecureAPITokenParameter
         S3ConfigBucket: !Ref S3ConfigBucket
+        VerifySSL: !If [ EndpointIsSaas, "Yes", "No" ]

--- a/templates/ECRImageScanning.yaml
+++ b/templates/ECRImageScanning.yaml
@@ -9,6 +9,15 @@ Parameters:
   SysdigSecureAPITokenSsm:
     Type: AWS::SSM::Parameter::Name
     Description: "Name of the parameter in SSM containing the Sysdig Secure API Token"
+  VerifySSL:
+    Type: String
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Default: "Yes"
+
+Conditions:
+  VerifySSL: !Equals [!Ref VerifySSL, "Yes"]
 
 Resources:
   ServiceRole:
@@ -109,20 +118,22 @@ Resources:
         PrivilegedMode: true
       Source:
         Type: NO_SOURCE
-        BuildSpec: !Sub |
-          version: 0.2
+        BuildSpec: !Sub
+          - |
+            version: 0.2
 
-          env:
-            variables:
-              SCAN_IMAGE_NAME: "quay.io/sysdig/secure-inline-scan:2"
-            parameter-store:
-              SYSDIG_SECURE_ENDPOINT: ${SysdigSecureEndpointSsm}
-              SYSDIG_SECURE_TOKEN: ${SysdigSecureAPITokenSsm}
+            env:
+              variables:
+                SCAN_IMAGE_NAME: "quay.io/sysdig/secure-inline-scan:2"
+              parameter-store:
+                SYSDIG_SECURE_ENDPOINT: ${SysdigSecureEndpointSsm}
+                SYSDIG_SECURE_TOKEN: ${SysdigSecureAPITokenSsm}
 
-          phases:
-            build:
-              commands:
-              - docker run --rm $SCAN_IMAGE_NAME -s $SYSDIG_SECURE_ENDPOINT --sysdig-token $SYSDIG_SECURE_TOKEN --registry-auth-basic AWS:$(aws ecr get-login-password --region $REGION) $ACCOUNT.dkr.ecr.$REGION.amazonaws.com/$REPOSITORY:$TAG
+            phases:
+              build:
+                commands:
+                - docker run --rm $SCAN_IMAGE_NAME -s $SYSDIG_SECURE_ENDPOINT ${SkipTLSFlag} --sysdig-token $SYSDIG_SECURE_TOKEN --registry-auth-basic AWS:$(aws ecr get-login-password --region $REGION) $ACCOUNT.dkr.ecr.$REGION.amazonaws.com/$REPOSITORY:$TAG
+          - SkipTLSFlag: !If [ VerifySSL, "", " --sysdig-skip-tls" ]
 
   InvokeRole:
     Type: AWS::IAM::Role

--- a/templates/ECSImageScanning.yaml
+++ b/templates/ECSImageScanning.yaml
@@ -8,6 +8,15 @@ Parameters:
   SysdigSecureAPITokenSsm:
     Type: AWS::SSM::Parameter::Name
     Description: "Name of the parameter in SSM containing the Sysdig Secure API Token"
+  VerifySSL:
+    Type: String
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Default: "Yes"
+
+Conditions:
+  VerifySSL: !Equals [!Ref VerifySSL, "Yes"]
 
 Resources:
   StartBuildRole:
@@ -164,95 +173,98 @@ Resources:
         PrivilegedMode: true
       Source:
         Type: NO_SOURCE
-        BuildSpec: !Sub |
-          version: 0.2
-          env:
-            variables:
-              SCAN_IMAGE_NAME: "quay.io/sysdig/secure-inline-scan:2"
-            parameter-store:
-              SYSDIG_SECURE_ENDPOINT: ${SysdigSecureEndpointSsm}
-              SYSDIG_SECURE_TOKEN: ${SysdigSecureAPITokenSsm}
-          phases:
-            build:
-              commands:
-              - |
-                  cat > app.py <<EOF
-                  import boto3
-                  import json
-                  import os
-                  import subprocess
-                  import sys
+        BuildSpec: !Sub
+          - |
+            version: 0.2
+            env:
+              variables:
+                SCAN_IMAGE_NAME: "quay.io/sysdig/secure-inline-scan:2"
+              parameter-store:
+                SYSDIG_SECURE_ENDPOINT: ${SysdigSecureEndpointSsm}
+                SYSDIG_SECURE_TOKEN: ${SysdigSecureAPITokenSsm}
+            phases:
+              build:
+                commands:
+                - |
+                    cat > app.py <<EOF
+                    import boto3
+                    import json
+                    import os
+                    import subprocess
+                    import sys
 
-                  def get_task_definition(task_definition_arn, region):
-                      client = boto3.client('ecs', region_name=region)
-                      return client.describe_task_definition(taskDefinition=task_definition_arn)
+                    def get_task_definition(task_definition_arn, region):
+                        client = boto3.client('ecs', region_name=region)
+                        return client.describe_task_definition(taskDefinition=task_definition_arn)
 
-                  def get_credentials_secret_for(container):
-                      if "repositoryCredentials" in container \
-                          and "credentialsParameter" in container["repositoryCredentials"]:
-                              return container["repositoryCredentials"]["credentialsParameter"]
-                      return None
+                    def get_credentials_secret_for(container):
+                        if "repositoryCredentials" in container \
+                            and "credentialsParameter" in container["repositoryCredentials"]:
+                                return container["repositoryCredentials"]["credentialsParameter"]
+                        return None
 
-                  def launch_scan(image, user, password):
-                      args = ["docker",
-                          "run",
-                          "--rm",
-                          os.getenv("SCAN_IMAGE_NAME"),
-                          "--sysdig-url={}".format(os.getenv("SYSDIG_SECURE_ENDPOINT")),
-                          "--sysdig-token={}".format(os.getenv("SYSDIG_SECURE_TOKEN")),
-                          image
-                          ]
+                    def launch_scan(image, user, password):
+                        args = ["docker",
+                            "run",
+                            "--rm",
+                            os.getenv("SCAN_IMAGE_NAME"),
+                            "--sysdig-url={}".format(os.getenv("SYSDIG_SECURE_ENDPOINT")),
+                            "--sysdig-token={}".format(os.getenv("SYSDIG_SECURE_TOKEN")),
+                            ${SkipTLSFlag}
+                            image
+                            ]
 
-                      print("Running: {}".format(" ".join(args)))
+                        print("Running: {}".format(" ".join(args)))
 
-                      if user:
-                          print("Adding --registry-auth-basic=***:***")
-                          args.append("--registry-auth-basic={}:{}".format(user,password))
+                        if user:
+                            print("Adding --registry-auth-basic=***:***")
+                            args.append("--registry-auth-basic={}:{}".format(user,password))
 
-                      ret = subprocess.run(args)
-                      if ret.returncode != 0 and ret.returncode != 1:
-                          print("Error executing inline-scan for image {}".format(image))
-                          return True
-                      return False
+                        ret = subprocess.run(args)
+                        if ret.returncode != 0 and ret.returncode != 1:
+                            print("Error executing inline-scan for image {}".format(image))
+                            return True
+                        return False
 
-                  def get_credentials_from_secret_manager(secret_id, region):
-                      client = boto3.client('secretsmanager', region_name=region)
-                      get_secret_value_response = client.get_secret_value(SecretId=secret_id)
-                      secret = json.loads(get_secret_value_response['SecretString'])
-                      return secret["username"], secret["password"]
+                    def get_credentials_from_secret_manager(secret_id, region):
+                        client = boto3.client('secretsmanager', region_name=region)
+                        get_secret_value_response = client.get_secret_value(SecretId=secret_id)
+                        secret = json.loads(get_secret_value_response['SecretString'])
+                        return secret["username"], secret["password"]
 
-                  def main():
-                      region = os.getenv("EVENT_REGION")
-                      task_definition_arn = os.getenv("EVENT_TASKDEFINITIONARN")
+                    def main():
+                        region = os.getenv("EVENT_REGION")
+                        task_definition_arn = os.getenv("EVENT_TASKDEFINITIONARN")
 
-                      if not task_definition_arn:
-                          print("taskDefinitionArn not found. Is EVENT_TASKDEFINITIONARN defined?")
-                          sys.exit(1)
-                      if not region:
-                          print("region not found. Is EVENT_REGION defined?")
-                          sys.exit(1)
-                      if not os.getenv("SCAN_IMAGE_NAME"):
-                          print("SCAN_IMAGE_NAME is not defined")
-                          sys.exit(1)
+                        if not task_definition_arn:
+                            print("taskDefinitionArn not found. Is EVENT_TASKDEFINITIONARN defined?")
+                            sys.exit(1)
+                        if not region:
+                            print("region not found. Is EVENT_REGION defined?")
+                            sys.exit(1)
+                        if not os.getenv("SCAN_IMAGE_NAME"):
+                            print("SCAN_IMAGE_NAME is not defined")
+                            sys.exit(1)
 
-                      task_definition = get_task_definition(task_definition_arn, region)
+                        task_definition = get_task_definition(task_definition_arn, region)
 
-                      failed_scan = False
-                      for container in task_definition["taskDefinition"]["containerDefinitions"]:
-                          image = container["image"]
-                          print("Checking image {} for container {} in task {}".format(image, container["name"], task_definition_arn))
-                          secret_id = get_credentials_secret_for(container)
-                          if secret_id:
-                              user, password = get_credentials_from_secret_manager(secret_id, region)
-                          else:
-                              user, password = "", ""
+                        failed_scan = False
+                        for container in task_definition["taskDefinition"]["containerDefinitions"]:
+                            image = container["image"]
+                            print("Checking image {} for container {} in task {}".format(image, container["name"], task_definition_arn))
+                            secret_id = get_credentials_secret_for(container)
+                            if secret_id:
+                                user, password = get_credentials_from_secret_manager(secret_id, region)
+                            else:
+                                user, password = "", ""
 
-                          failed_scan |= launch_scan(image, user, password)
+                            failed_scan |= launch_scan(image, user, password)
 
-                      if failed_scan:
-                          sys.exit(1)
+                        if failed_scan:
+                            sys.exit(1)
 
-                  if __name__ == "__main__":
-                      main()
-                  EOF
-              - python app.py
+                    if __name__ == "__main__":
+                        main()
+                    EOF
+                - python app.py
+          - SkipTLSFlag: !If [ VerifySSL, "", "\"--sysdig-skip-tls\"," ]


### PR DESCRIPTION
VerifyTLS is enabled by default if the Secure URL matches:
- https://secure.sysdig.com
- https://eu1.app.sysdig.com/secure
- https://us2.app.sysdig.com/secure

(can you confirm if the /secure is required or not?)

Every subchart now has a VerifyTLS parameter that enabled/disabled certificate verification. When VerifyTLS is disabled:

- For ECR and ECS scanning, it adds the `--sysdig-skip-tls` flag to the inline-scan execution
- For CloudConnector, it sets VERIFY_TLS="false" environment variable
- For CloudBench, it sets VERIFY_TLS="false" environment variable (although currently this is not honored, see PR)

Related PR for CloudBench: https://github.com/sysdiglabs/cloud-bench/pull/15