### PR TITLE
feat: allow ECS scanning to login into ECR registries without secrets

### DIFF
--- a/templates/ECSImageScanning.yaml
+++ b/templates/ECSImageScanning.yaml
@@ -85,6 +85,26 @@ Resources:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureEndpointSsm}
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureAPITokenSsm}
 
+        - PolicyName: ECRReader
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ecr:GetAuthorizationToken"
+                  - "ecr:BatchCheckLayerAvailability"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "ecr:GetRepositoryPolicy"
+                  - "ecr:DescribeRepositories"
+                  - "ecr:ListImages"
+                  - "ecr:DescribeImages"
+                  - "ecr:BatchGetImage"
+                  - "ecr:GetLifecyclePolicy"
+                  - "ecr:GetLifecyclePolicyPreview"
+                  - "ecr:ListTagsForResource"
+                  - "ecr:DescribeImageScanFindings"
+                Resource: "*"
+
         - PolicyName: TaskDefinitionReader
           PolicyDocument:
             Version: "2012-10-17"
@@ -212,7 +232,7 @@ Resources:
                             print("Adding --registry-auth-basic=***:***")
                             args.append("--registry-auth-basic={}:{}".format(user,password))
 
-                        ret = subprocess.run(args)
+                        ret = subprocess.run(" ".join(args), shell=True)
                         if ret.returncode != 0 and ret.returncode != 1:
                             print("Error executing inline-scan for image {}".format(image))
                             return True
@@ -247,6 +267,8 @@ Resources:
                             secret_id = get_credentials_secret_for(container)
                             if secret_id:
                                 user, password = get_credentials_from_secret_manager(secret_id, region)
+                            elif image.startswith("${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/"):
+                                user, password = "AWS", "$(aws ecr get-login-password --region ${AWS::Region})"
                             else:
                                 user, password = "", ""
 


### PR DESCRIPTION
it is possible to create tasks in ECS Fargate that pull from the ECR registry just by providing a role with access to the registry, no need to configure secrets in the task definition. This images will fail to analyze in the Codebuild project.

With this change, we provide pull permissions to ECR registry in the account (like the ECR scanning integration), and we use those permissions to authenticate using the `aws ecr get-login` command when the image is coming from the account ECR registry. 