### PR TITLE
feat: read cloud connector config from S3 bucket [SSPROD-6538]

### DIFF
--- a/templates/CloudConnector.yaml
+++ b/templates/CloudConnector.yaml
@@ -165,9 +165,7 @@ Resources:
             - Name: VERIFY_SSL
               Value: !If [ VerifySSL, "true", "false" ]
             - Name: CONFIG_PATH
-              Value: !Sub
-                - s3://${Bucket}/cloud-connector.yaml
-                - Bucket: !Ref S3ConfigBucket
+              Value: !Sub s3://${S3ConfigBucket}/cloud-connector.yaml
           Secrets:
             - Name: SECURE_URL
               ValueFrom: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SysdigSecureEndpointSsm}


### PR DESCRIPTION
Remove config volume and read config directly from S3 bucket in Cloud Connector.

In Cloud Bench, reading from S3 is not supported, so the init container dumps both to the S3 and config volume, and if config file exists in S3, it is read from the S3 bucket and dumped to the config volume.