### PR TITLE
fix: don't include the /secure prefix when comparing base URL

### DIFF
--- a/templates/CloudVision.yaml
+++ b/templates/CloudVision.yaml
@@ -125,10 +125,10 @@ Conditions:
         - "https://secure.sysdig.com"
       - Fn::Equals:
         - !Ref SysdigSecureEndpoint
-        - "https://eu1.app.sysdig.com/secure"
+        - "https://eu1.app.sysdig.com"
       - Fn::Equals:
         - !Ref SysdigSecureEndpoint
-        - "https://us2.app.sysdig.com/secure"
+        - "https://us2.app.sysdig.com"
 
 Resources:
   S3ConfigBucket:


### PR DESCRIPTION
The /secure suffix is not needed for non-default SaaS regions. Remove it in the check.