### PR TITLE
fix: revert ECR_DEPLOYED and ECS_DEPLOYED required parameters

### DIFF
--- a/templates/CloudScanning.yaml
+++ b/templates/CloudScanning.yaml
@@ -27,6 +27,16 @@ Parameters:
       - "Yes"
       - "No"
     Default: "Yes"
+  ECRDeployed:
+    Type: String
+    AllowedValues:
+      - "Yes"
+      - "No"
+  ECSDeployed:
+    Type: String
+    AllowedValues:
+      - "Yes"
+      - "No"
   BuildProject:
     Type: String
     Default: ""
@@ -36,6 +46,8 @@ Parameters:
 
 Conditions:
   VerifySSL: !Equals [!Ref VerifySSL, "Yes"]
+  ECRDeployed: !Equals [!Ref ECRDeployed, "Yes"]
+  ECSDeployed: !Equals [!Ref ECSDeployed, "Yes"]
 
 Resources:
 
@@ -200,6 +212,10 @@ Resources:
               Value: 30s
             - Name: CODEBUILD_PROJECT
               Value: !Sub ${BuildProject}
+            - Name: ECR_DEPLOYED
+              Value: !If [ ECRDeployed, "true", "false" ]
+            - Name: ECS_DEPLOYED
+              Value: !If [ ECSDeployed, "true", "false" ]
             - Name: TELEMETRY_DEPLOYMENT_METHOD
               Value: cft
           Secrets:

--- a/templates/CloudVision.yaml
+++ b/templates/CloudVision.yaml
@@ -202,6 +202,8 @@ Resources:
         SysdigSecureEndpointSsm: !Ref SysdigSecureEndpointParameter
         SysdigSecureAPITokenSsm: !Ref SysdigSecureAPITokenParameter
         VerifySSL: !If [ EndpointIsSaas, "Yes", "No" ]
+        ECRDeployed: !Ref ECRImageScanningDeploy
+        ECSDeployed: !Ref ECSImageScanningDeploy
         BuildProject: !GetAtt [ "ScanningCodeBuildStack", "Outputs.BuildProject" ]
         CloudTrailTopic: !If [ DeployCloudTrail, !GetAtt ["CloudTrailStack", "Outputs.Topic"], !Ref ExistentCloudTrailSNSTopic ]
 


### PR DESCRIPTION
These parameters are required for CloudScanning to enable the corresponding ECR and / or ECS notifiers and trigger the scans.