### PR TITLE
fix: force Domain VPC for EIP resources

### DIFF
--- a/templates/VPC.yaml
+++ b/templates/VPC.yaml
@@ -95,6 +95,7 @@ Resources:
     Type: AWS::EC2::EIP
     DependsOn: InternetGatewayAttachment
     Properties:
+      Domain: vpc
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName
@@ -103,6 +104,7 @@ Resources:
     Type: AWS::EC2::EIP
     DependsOn: InternetGatewayAttachment
     Properties:
+      Domain: vpc
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName


### PR DESCRIPTION
Domain defaults to "ec2" if EC2 classic is still supported in that account and region. This might be happening in https://sysdig.atlassian.net/browse/ESC-756

Force Domain: vpc to fix the problem.