### PR TITLE
feat: SSPROD-10132 Move create role option to Sysdig Settings while creating the CFT stack

### DIFF
--- a/templates/CloudVision.yaml
+++ b/templates/CloudVision.yaml
@@ -10,6 +10,7 @@ Metadata:
           - SysdigSecureEndpoint
           - SysdigSecureAPIToken
           - SysdigRoleName
+          - CreateSysdigRole
           - SysdigExternalID
           - SysdigTrustedIdentity
 
@@ -35,6 +36,8 @@ Metadata:
         default: "Sysdig Secure API Token"
       SysdigRoleName:
         default: "Sysdig Role Name"
+      CreateSysdigRole:
+        default: "Do you want to create Sysdig Role?"
       SysdigExternalID:
         default: "Sysdig External ID"
       SysdigTrustedIdentity:


### PR DESCRIPTION
Onboarding has the capability to support Agentless with CloudFormation. Customers can specify whether to create an IAM role for Agentless benchmarks while creating the stack. Today, this option is grouped under the “Modules to Deploy” section. It seems reasonable to move it under the Sysdig Settings to improve onboarding experience.