### PR TITLE
Support multiregion EB

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 * @sysdiglabs/cloud-native
-* @draios/team-secure-onboarding

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @sysdiglabs/cloud-native
+* @draios/team-secure-onboarding

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -1,7 +1,33 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: IAM Role and EventBridge resources used by Sysdig Secure       
+Description: CSPM and EventBridge resources needed for Sysdig Secure
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Sysdig Settings (Do not change)"
+        Parameters:
+          - CSPMRoleName
+          - EventBridgeRoleName
+          - ExternalID
+          - TrustedIdentity
+          - EventBusARN
+          - Regions
+          - OrganizationUnitIDs
+    ParameterLabels:
+      ExternalID:
+        default: "External ID (Sysdig use only)"
+      TrustedIdentity:
+        default: "Trusted Identity (Sysdig use only)"
+      EventBusARN:
+        default: "Target Event Bus (Sysdig use only)"
+      EventBridgeRoleName:
+        default: "Integration Name (Sysdig use only)"
+      Regions:
+        default: "EventBridge Regions (Sysdig use only)"
+      OrganizationUnitIDs:
+        default: "Organization Unit IDs (Sysdig use only)"       
 Parameters:
-  RoleName:
+  CSPMRoleName:
     Type: String
     Default: "sysdig-secure"
     Description: The read-only IAM Role that Sysdig will create
@@ -18,24 +44,29 @@ Parameters:
   EventBusARN:
     Type: String
     Description: The destination in Sysdig's AWS account where your events are sent
+  Regions:
+    Type: String
+    Description: Comma separated list of regions to monitor with EventBridge    
   OrganizationUnitIDs:
     Type: String
     Description: Organization Unit IDs to deploy    
 
 Resources:
-  FullInstallStackSet:
+  RolesStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
-      StackSetName: FullInstallStackSet
-      Description: Create StackSet needed for CSPM and Threat Detection
+      StackSetName: RolesStackSet
+      Description: IAM Role used to forward CloudTrail logs to Sysdig Secure
       PermissionModel: SERVICE_MANAGED
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
         Enabled: false
+      OperationPreferences:
+        MaxConcurrentCount: 5
       Parameters:
-        - ParameterKey: RoleName
-          ParameterValue: !Ref RoleName
+        - ParameterKey: CSPMRoleName
+          ParameterValue: !Ref CSPMRoleName      
         - ParameterKey: TrustedIdentity
           ParameterValue: !Ref TrustedIdentity
         - ParameterKey: ExternalID
@@ -43,38 +74,36 @@ Resources:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName
         - ParameterKey: EventBusARN
-          ParameterValue: !Ref EventBusARN                 
+          ParameterValue: !Ref EventBusARN
       StackInstancesGroup:
         - DeploymentTargets:
-            OrganizationalUnitIds:
-              - !Ref OrganizationUnitIDs
+            OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
           Regions:
-            - !Ref "AWS::Region"  
+            - !Ref "AWS::Region"
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
-        Description: StackSet for CSPM and Threat Detection
+        Description: IAM Role used to forward CloudTrail logs to Sysdig Secure
         Parameters:
-          RoleName:
+          CSPMRoleName:
             Type: String
-            Description: Role name
+            Description: A unique identifier used to create an IAM Role and EventBridge Rule        
           TrustedIdentity:
             Type: String
-            Description: Trusted identity
+            Description: The Role in Sysdig's AWS Account with permissions to your account
           ExternalID:
             Type: String
-            Description: External ID
+            Description: Sysdig ExternalID required for the policy creation
           EventBridgeRoleName:
             Type: String
-            Description: EventBridge Role Name
+            Description: A unique identifier used to create an IAM Role and EventBridge Rule
           EventBusARN:
             Type: String
-            Description: EventBus ARN            
-
+            Description: The destination in Sysdig's AWS account where your events are sent                        
         Resources:
           CloudAgentlessRole:
             Type: "AWS::IAM::Role"
             Properties:
-              RoleName: !Sub ${RoleName}
+              RoleName: !Sub ${CSPMRoleName}
               AssumeRolePolicyDocument:
                 Version: "2012-10-17"
                 Statement:
@@ -84,14 +113,15 @@ Resources:
                     Action: "sts:AssumeRole"
                     Condition:
                       StringEquals:
-                        sts:ExternalId: !Sub ${TrustedIdentity}
+                        sts:ExternalId: !Sub ${ExternalID}
               ManagedPolicyArns:
-                - arn:aws:iam::aws:policy/SecurityAudit
+                - arn:aws:iam::aws:policy/SecurityAudit        
           EventBridgeRole:
             Type: AWS::IAM::Role
             Properties:
               RoleName: !Sub ${EventBridgeRoleName}
               AssumeRolePolicyDocument:
+                Version: "2012-10-17"
                 Statement:
                   - Effect: Allow
                     Principal:
@@ -103,7 +133,7 @@ Resources:
                     Action: "sts:AssumeRole"
                     Condition:
                       StringEquals:
-                        sts:ExternalId: !Sub ${ExternalID}            
+                        sts:ExternalId: !Sub ${ExternalID}          
               Policies:
                 - PolicyName: !Sub ${EventBridgeRoleName}
                   PolicyDocument:
@@ -111,7 +141,39 @@ Resources:
                     Statement:
                       - Effect: Allow
                         Action: 'events:PutEvents'
-                        Resource: !Sub ${EventBusARN}      
+                        Resource: !Sub ${EventBusARN}
+  EBRuleStackSet:
+    Type: AWS::CloudFormation::StackSet
+    Properties:
+      StackSetName: EBRuleStackSet
+      Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure
+      PermissionModel: SERVICE_MANAGED
+      Capabilities:
+        - "CAPABILITY_NAMED_IAM"
+      AutoDeployment:
+        Enabled: false
+      OperationPreferences:
+        MaxConcurrentCount: 5
+      Parameters:
+        - ParameterKey: EventBridgeRoleName
+          ParameterValue: !Ref EventBridgeRoleName
+        - ParameterKey: EventBusARN
+          ParameterValue: !Ref EventBusARN                      
+      StackInstancesGroup:
+        - DeploymentTargets:
+            OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
+          Regions: !Split [ ",", !Ref Regions]
+      TemplateBody: |
+        AWSTemplateFormatVersion: "2010-09-09"
+        Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure
+        Parameters:
+          EventBridgeRoleName:
+            Type: String
+            Description: A unique identifier used to create an IAM Role and EventBridge Rule
+          EventBusARN:
+            Type: String
+            Description: The destination in Sysdig's AWS account where your events are sent                        
+        Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
             Properties:
@@ -125,10 +187,5 @@ Resources:
               Targets:
                 - Id: !Sub ${EventBridgeRoleName}
                   Arn: !Sub ${EventBusARN}
-                  RoleArn: !GetAtt [EventBridgeRole, Arn]
-
-        Outputs:
-          RuleARN:
-            Description: ARN of the rule created
-            Value: !Sub ${EventBridgeRule.Arn}
+                  RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${EventBridgeRoleName}"                        
             

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: CSPM and EventBridge resources needed for Sysdig Secure
+Description: IAM Role and EventBridge resources used by Sysdig Secure
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -14,14 +14,16 @@ Metadata:
           - Regions
           - OrganizationUnitIDs
     ParameterLabels:
+      CSPMRoleName:
+        default: "CSPM Role Name (Sysdig use only)"
+      EventBridgeRoleName:
+        default: "Integration Name (Sysdig use only)"        
       ExternalID:
         default: "External ID (Sysdig use only)"
       TrustedIdentity:
         default: "Trusted Identity (Sysdig use only)"
       EventBusARN:
         default: "Target Event Bus (Sysdig use only)"
-      EventBridgeRoleName:
-        default: "Integration Name (Sysdig use only)"
       Regions:
         default: "EventBridge Regions (Sysdig use only)"
       OrganizationUnitIDs:

--- a/templates_eventbridge/EventBridge.yaml
+++ b/templates_eventbridge/EventBridge.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: EventBridge resource that forward CloudTrail logs to Sysdig Secure
+Description: EventBridge resources that forward CloudTrail logs to Sysdig Secure
 
 Metadata:
   AWS::CloudFormation::Interface:

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -10,6 +10,7 @@ Metadata:
           - ExternalID
           - TrustedIdentity
           - EventBusARN
+          - Regions
     ParameterLabels:
       ExternalID:
         default: "External ID (Sysdig use only)"
@@ -19,6 +20,10 @@ Metadata:
         default: "Target Event Bus (Sysdig use only)"
       EventBridgeRoleName:
         default: "Integration Name (Sysdig use only)"
+      Regions:
+        default: "EventBridge Regions (Sysdig use only)"
+      OrganizationUnitIDs:
+        default: "Organization Unit IDs (Sysdig use only)"
 Parameters:
   EventBridgeRoleName:
     Type: String
@@ -33,9 +38,12 @@ Parameters:
   EventBusARN:
     Type: String
     Description: The destination in Sysdig's AWS account where your events are sent
+  Regions:
+    Type: String
+    Description: Comma separated list of regions to monitor with EventBridge
   OrganizationUnitIDs:
     Type: String
-    Description: Organization Unit IDs to deploy
+    Description: Comma separated list of Organization Unit IDs to deploy
 Resources:
   EBRoleStackSet:
     Type: AWS::CloudFormation::StackSet
@@ -126,11 +134,8 @@ Resources:
           ParameterValue: !Ref EventBusARN                      
       StackInstancesGroup:
         - DeploymentTargets:
-            OrganizationalUnitIds:
-              - !Ref OrganizationUnitIDs
-          Regions:
-            - 'us-east-1'
-            - 'us-west-2'
+            OrganizationalUnitIds: !Split [ ",", !Ref Regions]
+          Regions: !Split [ ",", !Ref Regions]
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
         Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -19,16 +19,18 @@ Parameters:
     Description: Organization Unit IDs to deploy    
 
 Resources:
-  EBRuleStackSet:
+  EBRoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
-      StackSetName: EBRuleStackSet
+      StackSetName: EBRoleStackSet
       Description: Create a Stackset for creation of resources needed for Threat Detection
       PermissionModel: SERVICE_MANAGED
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
         Enabled: false
+      OperationPreferences:
+        MaxConcurrentCount: 5
       Parameters:
         - ParameterKey: TrustedIdentity
           ParameterValue: !Ref TrustedIdentity
@@ -37,16 +39,16 @@ Resources:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName
         - ParameterKey: EventBusARN
-          ParameterValue: !Ref EventBusARN                      
+          ParameterValue: !Ref EventBusARN
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds:
               - !Ref OrganizationUnitIDs
           Regions:
-            - !Ref "AWS::Region"  
+            - !Ref "AWS::Region"
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
-        Description: Stackset for Threat Detection
+        Description: Role for Threat Detection
         Parameters:
           TrustedIdentity:
             Type: String
@@ -60,7 +62,6 @@ Resources:
           EventBusARN:
             Type: String
             Description: EventBus ARN                        
-
         Resources:
           EventBridgeRole:
             Type: AWS::IAM::Role
@@ -87,7 +88,42 @@ Resources:
                     Statement:
                       - Effect: Allow
                         Action: 'events:PutEvents'
-                        Resource: !Sub ${EventBusARN}               
+                        Resource: !Sub ${EventBusARN}
+  EBRuleStackSet:
+    Type: AWS::CloudFormation::StackSet
+    Properties:
+      StackSetName: EBRuleStackSet
+      Description: Create a Stackset for creation of resources needed for Threat Detection
+      PermissionModel: SERVICE_MANAGED
+      Capabilities:
+        - "CAPABILITY_NAMED_IAM"
+      AutoDeployment:
+        Enabled: false
+      OperationPreferences:
+        MaxConcurrentCount: 5
+      Parameters:
+        - ParameterKey: EventBridgeRoleName
+          ParameterValue: !Ref EventBridgeRoleName
+        - ParameterKey: EventBusARN
+          ParameterValue: !Ref EventBusARN                      
+      StackInstancesGroup:
+        - DeploymentTargets:
+            OrganizationalUnitIds:
+              - !Ref OrganizationUnitIDs
+          Regions:
+            - 'us-east-1'
+            - 'us-west-2'
+      TemplateBody: |
+        AWSTemplateFormatVersion: "2010-09-09"
+        Description: Stackset for Threat Detection
+        Parameters:
+          EventBridgeRoleName:
+            Type: String
+            Description: EventBridge Role Name
+          EventBusARN:
+            Type: String
+            Description: EventBus ARN                        
+        Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
             Properties:
@@ -101,9 +137,4 @@ Resources:
               Targets:
                 - Id: !Sub ${EventBridgeRoleName}
                   Arn: !Sub ${EventBusARN}
-                  RoleArn: !GetAtt [EventBridgeRole, Arn]
-                    
-        Outputs:
-          RuleARN:
-            Description: ARN of the rule created
-            Value: !Sub ${EventBridgeRule.Arn}
+                  RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${EventBridgeRoleName}"

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -13,14 +13,14 @@ Metadata:
           - Regions
           - OrganizationUnitIDs
     ParameterLabels:
+      EventBridgeRoleName:
+        default: "Integration Name (Sysdig use only)"    
       ExternalID:
         default: "External ID (Sysdig use only)"
       TrustedIdentity:
         default: "Trusted Identity (Sysdig use only)"
       EventBusARN:
         default: "Target Event Bus (Sysdig use only)"
-      EventBridgeRoleName:
-        default: "Integration Name (Sysdig use only)"
       Regions:
         default: "EventBridge Regions (Sysdig use only)"
       OrganizationUnitIDs:

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -1,5 +1,24 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: EventBridgeRole and EventBridgeRule for falco cloud
+Description: EventBridge resources that forward CloudTrail logs to Sysdig Secure
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Sysdig Settings (Do not change)"
+        Parameters:
+          - EventBridgeRoleName
+          - ExternalID
+          - TrustedIdentity
+          - EventBusARN
+    ParameterLabels:
+      ExternalID:
+        default: "External ID (Sysdig use only)"
+      TrustedIdentity:
+        default: "Trusted Identity (Sysdig use only)"
+      EventBusARN:
+        default: "Target Event Bus (Sysdig use only)"
+      EventBridgeRoleName:
+        default: "Integration Name (Sysdig use only)"
 Parameters:
   EventBridgeRoleName:
     Type: String
@@ -16,14 +35,13 @@ Parameters:
     Description: The destination in Sysdig's AWS account where your events are sent
   OrganizationUnitIDs:
     Type: String
-    Description: Organization Unit IDs to deploy    
-
+    Description: Organization Unit IDs to deploy
 Resources:
   EBRoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
       StackSetName: EBRoleStackSet
-      Description: Create a Stackset for creation of resources needed for Threat Detection
+      Description: IAM Role used to forward CloudTrail logs to Sysdig Secure
       PermissionModel: SERVICE_MANAGED
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
@@ -48,20 +66,20 @@ Resources:
             - !Ref "AWS::Region"
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
-        Description: Role for Threat Detection
+        Description: IAM Role used to forward CloudTrail logs to Sysdig Secure
         Parameters:
           TrustedIdentity:
             Type: String
-            Description: Trusted identity
+            Description: The Role in Sysdig's AWS Account with permissions to your account
           ExternalID:
             Type: String
-            Description: External ID
+            Description: Sysdig ExternalID required for the policy creation
           EventBridgeRoleName:
             Type: String
-            Description: EventBridge Role Name
+            Description: A unique identifier used to create an IAM Role and EventBridge Rule
           EventBusARN:
             Type: String
-            Description: EventBus ARN                        
+            Description: The destination in Sysdig's AWS account where your events are sent                        
         Resources:
           EventBridgeRole:
             Type: AWS::IAM::Role
@@ -93,7 +111,7 @@ Resources:
     Type: AWS::CloudFormation::StackSet
     Properties:
       StackSetName: EBRuleStackSet
-      Description: Create a Stackset for creation of resources needed for Threat Detection
+      Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure
       PermissionModel: SERVICE_MANAGED
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
@@ -115,14 +133,14 @@ Resources:
             - 'us-west-2'
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
-        Description: Stackset for Threat Detection
+        Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure
         Parameters:
           EventBridgeRoleName:
             Type: String
-            Description: EventBridge Role Name
+            Description: A unique identifier used to create an IAM Role and EventBridge Rule
           EventBusARN:
             Type: String
-            Description: EventBus ARN                        
+            Description: The destination in Sysdig's AWS account where your events are sent                        
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -11,6 +11,7 @@ Metadata:
           - TrustedIdentity
           - EventBusARN
           - Regions
+          - OrganizationUnitIDs
     ParameterLabels:
       ExternalID:
         default: "External ID (Sysdig use only)"
@@ -68,8 +69,7 @@ Resources:
           ParameterValue: !Ref EventBusARN
       StackInstancesGroup:
         - DeploymentTargets:
-            OrganizationalUnitIds:
-              - !Ref OrganizationUnitIDs
+            OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
           Regions:
             - !Ref "AWS::Region"
       TemplateBody: |
@@ -134,7 +134,7 @@ Resources:
           ParameterValue: !Ref EventBusARN                      
       StackInstancesGroup:
         - DeploymentTargets:
-            OrganizationalUnitIds: !Split [ ",", !Ref Regions]
+            OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
           Regions: !Split [ ",", !Ref Regions]
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"


### PR DESCRIPTION
Add multiregion support for EventBridge and Full install flows by creating two stacksets. One to create global resources in a single region, and one to create regional resources in multiple regions.