### PR TITLE
Add Onboarding team as Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sysdiglabs/cloud-native
+* @sysdiglabs/cloud-native @sysdiglabs/team-secure-onboarding


### PR DESCRIPTION
The Onboarding team is starting to contribute and maintain templates in this directory. Adding this team as codeowners to help manage this repository. 

See team here: https://github.com/orgs/sysdiglabs/teams/team-secure-onboarding/members