### PR TITLE
Resolve race condition, apply roles in single region

### DIFF
--- a/templates_cspm/CloudAgentlessRole.yaml
+++ b/templates_cspm/CloudAgentlessRole.yaml
@@ -22,7 +22,6 @@ Metadata:
 Parameters:
   RoleName:
     Type: String
-    Default: "sysdig-secure"
     Description: The read-only IAM Role that Sysdig will create
   ExternalID:
     Type: String

--- a/templates_cspm/OrgCloudAgentlessRole.yaml
+++ b/templates_cspm/OrgCloudAgentlessRole.yaml
@@ -22,7 +22,6 @@ Metadata:
 Parameters:
   RoleName:
     Type: String
-    Default: "sysdig-secure"
     Description: Unique role for monitoring AWS accounts
   ExternalID:
     Type: String

--- a/templates_cspm_eventbridge/FullInstall.yaml
+++ b/templates_cspm_eventbridge/FullInstall.yaml
@@ -29,11 +29,9 @@ Metadata:
 Parameters:
   RoleName:
     Type: String
-    Default: "sysdig-secure"
     Description: The read-only IAM Role that Sysdig will create
   EventBridgeRoleName:
     Type: String
-    Default: "sysdig-secure-cloudtrail"
     Description: A unique identifier used to create an IAM Role and EventBridge Rule
   ExternalID:
     Type: String

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -31,11 +31,9 @@ Metadata:
 Parameters:
   CSPMRoleName:
     Type: String
-    Default: "sysdig-secure"
     Description: The read-only IAM Role that Sysdig will create
   EventBridgeRoleName:
     Type: String
-    Default: "sysdig-secure-cloudtrail"
     Description: A unique identifier used to create an IAM Role and EventBridge Rule
   ExternalID:
     Type: String
@@ -124,7 +122,7 @@ Resources:
             Action: "sts:AssumeRole"
             Condition:
               StringEquals:
-                sts:ExternalId: !Sub ${ExternalID}          
+                sts:ExternalId: !Sub ${ExternalID}
       Policies:
         - PolicyName: !Sub ${EventBridgeRoleName}
           PolicyDocument:
@@ -132,7 +130,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: 'events:PutEvents'
-                Resource: !Sub ${EventBusARN}        
+                Resource: !Sub ${EventBusARN}
   RolesStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
@@ -147,7 +145,7 @@ Resources:
         MaxConcurrentCount: 5
       Parameters:
         - ParameterKey: CSPMRoleName
-          ParameterValue: !Ref CSPMRoleName      
+          ParameterValue: !Ref CSPMRoleName
         - ParameterKey: TrustedIdentity
           ParameterValue: !Ref TrustedIdentity
         - ParameterKey: ExternalID
@@ -159,7 +157,7 @@ Resources:
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
-          Regions: !Split [ ",", !Ref Regions]
+          Regions: [!Ref "AWS::Region"]
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
         Description: IAM Role used to forward CloudTrail logs to Sysdig Secure
@@ -238,7 +236,7 @@ Resources:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName
         - ParameterKey: EventBusARN
-          ParameterValue: !Ref EventBusARN                      
+          ParameterValue: !Ref EventBusARN
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
@@ -277,18 +275,18 @@ Resources:
       Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure
       PermissionModel: SELF_MANAGED
       Capabilities:
-        - CAPABILITY_NAMED_IAM              
+        - CAPABILITY_NAMED_IAM
       OperationPreferences:
         MaxConcurrentCount: 5
       Parameters:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName
         - ParameterKey: EventBusARN
-          ParameterValue: !Ref EventBusARN                      
+          ParameterValue: !Ref EventBusARN
       StackInstancesGroup:
         - DeploymentTargets:
-            Accounts: 
-              - !Ref AWS::AccountId             
+            Accounts:
+              - !Ref AWS::AccountId
           Regions: !Split [ ",", !Ref Regions]
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
@@ -314,4 +312,4 @@ Resources:
               Targets:
                 - Id: !Sub ${EventBridgeRoleName}
                   Arn: !Sub ${EventBusARN}
-                  RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${EventBridgeRoleName}"                 
+                  RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${EventBridgeRoleName}"

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -66,7 +66,6 @@ Resources:
               Service: cloudformation.amazonaws.com
             Action:
               - sts:AssumeRole
-      Path: /
       Policies:
         - PolicyName: AssumeRole-AWSCloudFormationStackSetExecutionRole
           PolicyDocument:
@@ -90,9 +89,8 @@ Resources:
                 - !GetAtt AdministrationRole.RoleId
             Action:
               - sts:AssumeRole
-      Path: /
       ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess
+        - !Sub arn:aws:iam::aws:policy/AdministratorAccess
   CloudAgentlessRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -275,7 +273,7 @@ Resources:
     DependsOn: ExecutionRole
     Properties:
       StackSetName: MgmtAccEBRuleStackSet
-      AdministrationRoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/AWSCloudFormationStackSetAdministrationRole
+      AdministrationRoleARN: !GetAtt AdministrationRole.Arn
       Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure
       PermissionModel: SELF_MANAGED
       Capabilities:

--- a/templates_eventbridge/EventBridge.yaml
+++ b/templates_eventbridge/EventBridge.yaml
@@ -25,7 +25,6 @@ Metadata:
 Parameters:
   EventBridgeRoleName:
     Type: String
-    Default: "sysdig-secure-cloudtrail"
     Description: A unique identifier used to create an IAM Role and EventBridge Rule
   ExternalID:
     Type: String

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -34,7 +34,6 @@ Parameters:
     Description: Unique role for monitoring AWS accounts
   EventBridgeRoleName:
     Type: String
-    Default: "sysdig-secure-cloudtrail"
     Description: A unique identifier used to create an IAM Role and EventBridge Rule
   ExternalID:
     Type: String
@@ -202,7 +201,7 @@ Resources:
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
-          Regions: !Split [ ",", !Ref Regions]
+          Regions: [!Ref "AWS::Region"]
       TemplateBody: |
         AWSTemplateFormatVersion: "2010-09-09"
         Description: IAM Role used to forward CloudTrail logs to Sysdig Secure

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -64,7 +64,6 @@ Resources:
               Service: cloudformation.amazonaws.com
             Action:
               - sts:AssumeRole
-      Path: /
       Policies:
         - PolicyName: AssumeRole-AWSCloudFormationStackSetExecutionRole
           PolicyDocument:
@@ -88,9 +87,8 @@ Resources:
                 - !GetAtt AdministrationRole.RoleId
             Action:
               - sts:AssumeRole
-      Path: /
       ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess                  
+        - !Sub arn:aws:iam::aws:policy/AdministratorAccess
   MgmtAccCloudAgentlessRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -138,7 +136,7 @@ Resources:
     DependsOn: ExecutionRole
     Properties:
       StackSetName: MgmtAccEBRuleStackSet
-      AdministrationRoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/AWSCloudFormationStackSetAdministrationRole
+      AdministrationRoleARN: !GetAtt AdministrationRole.Arn
       Description: EventBridge Resources that forward CloudTrail logs to Sysdig Secure
       PermissionModel: SELF_MANAGED
       Capabilities:


### PR DESCRIPTION
Tested this out and there is a race condition where if `MgmtAccEBRuleStackSet` is created before `AdministrationRole`, the stackset fails to create. This PR makes `MgmtAccEBRuleStackSet` directly depend on `AdministrationRole`, which ensures the resources are created in the right order.

Fixes a bug where role stacksets were applied to all regions instead of just one

Removes default role names

It also includes some simplifications such as removing `Path: /` (which is [the default](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-path)), and `${AWS::Partition}` (since we don't support china or gov cloud)

