### PR TITLE
fix: self managed stackset dependencies

### DIFF
--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -268,7 +268,14 @@ Resources:
                   RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${EventBridgeRoleName}"
   MgmtAccEBRuleStackSet:
     Type: AWS::CloudFormation::StackSet
-    DependsOn: ExecutionRole
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3005
+    DependsOn: 
+      - ExecutionRole
+      - AdministrationRole
     Properties:
       StackSetName: MgmtAccEBRuleStackSet
       AdministrationRoleARN: !GetAtt AdministrationRole.Arn

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -132,7 +132,14 @@ Resources:
                 Resource: !Sub ${EventBusARN}
   MgmtAccEBRuleStackSet:
     Type: AWS::CloudFormation::StackSet
-    DependsOn: ExecutionRole
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3005
+    DependsOn: 
+      - ExecutionRole
+      - AdministrationRole
     Properties:
       StackSetName: MgmtAccEBRuleStackSet
       AdministrationRoleARN: !GetAtt AdministrationRole.Arn


### PR DESCRIPTION
adds an explicit dependency between MgmtAccEBRuleStackSet and associated self managed roles Even though there is an implicit dependency because of the use of Fn::GetAtt, we also need an explicit dependency to handle stack teardown gracefully. Adds cfn-lint exclusion