### PR TITLE
Add CloudLogs module for AWS Onboarding 

### DIFF
--- a/.github/workflows/ci-master-cloudlogs.yaml
+++ b/.github/workflows/ci-master-cloudlogs.yaml
@@ -1,0 +1,33 @@
+name: CI - Master CSPM
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'templates_cloudlogs/**'
+
+
+jobs:
+  build:
+    name: Build and Upload
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+
+    - name: Build and Upload Cloudlogs templates
+      run: make ci
+      working-directory: ./templates_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: master
+

--- a/.github/workflows/ci-master-cloudlogs.yaml
+++ b/.github/workflows/ci-master-cloudlogs.yaml
@@ -1,4 +1,4 @@
-name: CI - Master CSPM
+name: CI - Master CloudLogs
 
 on:
   push:

--- a/.github/workflows/ci-master-full-install-with-cloudlogs.yaml
+++ b/.github/workflows/ci-master-full-install-with-cloudlogs.yaml
@@ -1,0 +1,39 @@
+name: CI - Master Full Install
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'templates_cspm_cloudlogs/**'
+
+
+jobs:
+  build:
+    name: Build and Upload
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+
+    - name: Build and Upload Full install templates
+      run: make ci
+      working-directory: ./templates_cspm_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: master
+
+    - name: Build and Upload Full install templates
+      run: make ci-org
+      working-directory: ./templates_cspm_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: master        

--- a/.github/workflows/ci-pull-request-cloudlogs.yaml
+++ b/.github/workflows/ci-pull-request-cloudlogs.yaml
@@ -1,0 +1,48 @@
+name: CI - Pull Request Cloudlogs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'templates_cloudlogs/**'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: cfn-lint
+      uses: scottbrenner/cfn-lint-action@v2
+
+    - name: Print the Cloud Formation Linter Version & run Linter
+      run: |
+        cfn-lint --version
+        cfn-lint -t templates_cloudlogs/**/*.yaml
+
+  build:
+    name: Build and Upload Cloudlogs templates
+    runs-on: ubuntu-latest
+    needs: [lint]
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+
+    - name: Build and Upload Cloudlogs Templates
+      run: make ci
+      working-directory: templates_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: pr/${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ci-pull-request-full-install-with-cloudlogs.yaml
+++ b/.github/workflows/ci-pull-request-full-install-with-cloudlogs.yaml
@@ -1,0 +1,55 @@
+name: CI - Pull Request Full Install
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'templates_cspm_cloudlogs/**'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: cfn-lint
+      uses: scottbrenner/cfn-lint-action@v2
+
+    - name: Print the Cloud Formation Linter Version & run Linter
+      run: |
+        cfn-lint --version
+        cfn-lint -t templates_cspm_cloudlogs/**/*.yaml
+
+  build:
+    name: Build and Upload Full Install templates
+    runs-on: ubuntu-latest
+    needs: [lint]
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+
+    - name: Build and Upload Full Install Templates
+      run: make ci
+      working-directory: templates_cspm_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: pr/${{ github.event.pull_request.head.ref }}
+
+    - name: Build and Upload Full Install Org Templates
+      run: make ci-org
+      working-directory: templates_cspm_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: pr/${{ github.event.pull_request.head.ref }}

--- a/templates_cloudlogs/CloudLogs.yaml
+++ b/templates_cloudlogs/CloudLogs.yaml
@@ -1,0 +1,51 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudFormation template for provisioning
+  the necessary resources for the `cloud-logs`
+  component.
+Resources:
+  CloudLogs:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref RoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref TrustedIdentity
+            Action:
+              - "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ExternalId
+  RolePolicies:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "CloudlogsS3Access"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "CloudlogsS3Access"
+            Effect: "Allow"
+            Action:
+              - "s3:Get*"
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}'
+              - !Sub '${BucketARN}/*'
+      Roles:
+        - Ref: "CloudLogs"
+Parameters:
+  BucketARN:
+    Type: String
+    Description: (Required) The ARN of your s3 bucket associated with your Cloudtrail trail.
+  ExternalId:
+    Type: String
+    Description: (Required) Random string generated unique to a customer.
+  TrustedIdentity:
+    Type: String
+    Description: (Required) The name of Sysdig trusted identity.
+  RoleName:
+    Type: String
+    Description: (Required) The name of the IAM Role that will enable access to the Cloudtrail logs.

--- a/templates_cloudlogs/CloudLogs.yaml
+++ b/templates_cloudlogs/CloudLogs.yaml
@@ -11,14 +11,14 @@ Metadata:
           default: "Sysdig Settings (Do not change)"
         Parameters:
           - RoleName
-          - ExternalID
+          - ExternalId
           - TrustedIdentity
           - BucketARN
 
     ParameterLabels:
       RoleName:
         default: "Role Name (Sysdig use only)"
-      ExternalID:
+      ExternalId:
         default: "External ID (Sysdig use only)"
       TrustedIdentity:
         default: "Trusted Identity (Sysdig use only)"
@@ -71,4 +71,4 @@ Resources:
               - !Sub '${BucketARN}'
               - !Sub '${BucketARN}/*'
       Roles:
-        - Ref: "CloudLogs"
+        - Ref: "CloudLogsRole"

--- a/templates_cloudlogs/CloudLogs.yaml
+++ b/templates_cloudlogs/CloudLogs.yaml
@@ -3,6 +3,42 @@ Description: >
   CloudFormation template for provisioning
   the necessary resources for the `cloud-logs`
   component.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Sysdig Settings (Do not change)"
+        Parameters:
+          - RoleName
+          - ExternalID
+          - TrustedIdentity
+          - BucketARN
+
+    ParameterLabels:
+      RoleName:
+        default: "Role Name (Sysdig use only)"
+      ExternalID:
+        default: "External ID (Sysdig use only)"
+      TrustedIdentity:
+        default: "Trusted Identity (Sysdig use only)"
+      BucketARN:
+        default: "Bucket ARN"
+
+Parameters:
+  RoleName:
+    Type: String
+    Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
+  ExternalId:
+    Type: String
+    Description: Random string generated unique to a customer.
+  TrustedIdentity:
+    Type: String
+    Description: The name of Sysdig trusted identity.
+  BucketARN:
+    Type: String
+    Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+
 Resources:
   CloudLogs:
     Type: "AWS::IAM::Role"
@@ -36,16 +72,3 @@ Resources:
               - !Sub '${BucketARN}/*'
       Roles:
         - Ref: "CloudLogs"
-Parameters:
-  BucketARN:
-    Type: String
-    Description: (Required) The ARN of your s3 bucket associated with your Cloudtrail trail.
-  ExternalId:
-    Type: String
-    Description: (Required) Random string generated unique to a customer.
-  TrustedIdentity:
-    Type: String
-    Description: (Required) The name of Sysdig trusted identity.
-  RoleName:
-    Type: String
-    Description: (Required) The name of the IAM Role that will enable access to the Cloudtrail logs.

--- a/templates_cloudlogs/CloudLogs.yaml
+++ b/templates_cloudlogs/CloudLogs.yaml
@@ -40,7 +40,7 @@ Parameters:
     Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
 
 Resources:
-  CloudLogs:
+  CloudLogsRole:
     Type: "AWS::IAM::Role"
     Properties:
       RoleName: !Ref RoleName
@@ -55,7 +55,7 @@ Resources:
             Condition:
               StringEquals:
                 "sts:ExternalId": !Ref ExternalId
-  RolePolicies:
+  CloudLogsRolePolicies:
     Type: "AWS::IAM::Policy"
     Properties:
       PolicyName: "CloudlogsS3Access"

--- a/templates_cloudlogs/Makefile
+++ b/templates_cloudlogs/Makefile
@@ -1,0 +1,41 @@
+# requires AWS_PROFILE
+# bucket must exist, prefix will be created
+S3_BUCKET ?= "s4c-cft"
+S3_PREFIX ?= "test"
+# We need the REGION or the TemplateURLs might be created for a different region, resulting in a deployment error
+S3_REGION ?= "eu-west-1" # ireland
+SECURE_API_TOKEN ?= ""
+STACK_NAME = "CloudLogsTest"
+
+.PHONY: packaged-template.yaml
+
+validate:
+	aws cloudformation validate-template --template-body file://./CloudLogs.yaml
+
+lint:
+	cfn-lint *.yaml
+
+packaged-template.yaml:
+	aws s3 rm s3://$(S3_BUCKET)/cloudlogs/$(S3_PREFIX) --recursive
+
+	aws cloudformation package \
+		--region $(S3_REGION) \
+		--template-file CloudLogs.yaml \
+		--s3-bucket $(S3_BUCKET) \
+		--s3-prefix cspm/$(S3_PREFIX) \
+		--force-upload \
+		--output-template-file packaged-template.yaml
+
+test: packaged-template.yaml
+	aws cloudformation deploy \
+		--stack-name $(STACK_NAME) \
+		--template-file packaged-template.yaml \
+		--capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" \
+		--parameter-overrides \
+			"SysdigSecureAPIToken=$(SECURE_API_TOKEN)"
+
+ci: packaged-template.yaml
+	aws s3 cp ./packaged-template.yaml s3://$(S3_BUCKET)/cloudlogs/$(S3_PREFIX)/entry-point.yaml
+
+clean:
+	aws cloudformation delete-stack --stack-name $(STACK_NAME)

--- a/templates_cspm_cloudlogs/FullInstall.yaml
+++ b/templates_cspm_cloudlogs/FullInstall.yaml
@@ -1,0 +1,94 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: IAM Roles for CSPM and Cloudlogs used by Sysdig Secure
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Sysdig Settings (Do not change)"
+        Parameters:
+          - CSPMRoleName
+          - CloudLogsRoleName
+          - ExternalID
+          - TrustedIdentity
+          - BucketARN
+
+    ParameterLabels:
+      CSPMRoleName:
+        default: "CSPM Role Name (Sysdig use only)"
+      CloudLogsRoleName:
+        default: "CloudLogs Role Name (Sysdig use only)"
+      ExternalID:
+        default: "External ID (Sysdig use only)"
+      TrustedIdentity:
+        default: "Trusted Identity (Sysdig use only)"
+      BucketARN:
+        default: "Bucket ARN"
+
+Parameters:
+  CSPMRoleName:
+    Type: String
+    Description: The read-only IAM Role that Sysdig will create
+  CloudLogsRoleName:
+    Type: String
+    Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
+  EventBridgeRoleName:
+    Type: String
+    Description: A unique identifier used to create an IAM Role and EventBridge Rule
+  ExternalID:
+    Type: String
+    Description: Sysdig ExternalID required for the policy creation
+  BucketARN:
+    Type: String
+    Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+
+Resources:
+  CloudAgentlessRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref CSPMRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS: !Ref TrustedIdentity
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalID
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/SecurityAudit
+  CloudLogsRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref CloudLogsRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref TrustedIdentity
+            Action:
+              - "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ExternalId
+  CloudLogsRolePolicies:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "CloudlogsS3Access"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "CloudlogsS3Access"
+            Effect: "Allow"
+            Action:
+              - "s3:Get*"
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}'
+              - !Sub '${BucketARN}/*'
+      Roles:
+        - Ref: "CloudLogs"

--- a/templates_cspm_cloudlogs/FullInstall.yaml
+++ b/templates_cspm_cloudlogs/FullInstall.yaml
@@ -9,7 +9,7 @@ Metadata:
         Parameters:
           - CSPMRoleName
           - CloudLogsRoleName
-          - ExternalID
+          - ExternalId
           - TrustedIdentity
           - BucketARN
 
@@ -18,7 +18,7 @@ Metadata:
         default: "CSPM Role Name (Sysdig use only)"
       CloudLogsRoleName:
         default: "CloudLogs Role Name (Sysdig use only)"
-      ExternalID:
+      ExternalId:
         default: "External ID (Sysdig use only)"
       TrustedIdentity:
         default: "Trusted Identity (Sysdig use only)"
@@ -32,12 +32,12 @@ Parameters:
   CloudLogsRoleName:
     Type: String
     Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
-  EventBridgeRoleName:
-    Type: String
-    Description: A unique identifier used to create an IAM Role and EventBridge Rule
-  ExternalID:
+  ExternalId:
     Type: String
     Description: Sysdig ExternalID required for the policy creation
+  TrustedIdentity:
+    Type: String
+    Description: The name of Sysdig trusted identity.
   BucketARN:
     Type: String
     Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
@@ -57,7 +57,7 @@ Resources:
             Action: "sts:AssumeRole"
             Condition:
               StringEquals:
-                sts:ExternalId: !Ref ExternalID
+                sts:ExternalId: !Ref ExternalId
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/SecurityAudit
   CloudLogsRole:
@@ -91,4 +91,4 @@ Resources:
               - !Sub '${BucketARN}'
               - !Sub '${BucketARN}/*'
       Roles:
-        - Ref: "CloudLogs"
+        - Ref: "CloudLogsRole"

--- a/templates_cspm_cloudlogs/Makefile
+++ b/templates_cspm_cloudlogs/Makefile
@@ -1,0 +1,67 @@
+# requires AWS_PROFILE
+# bucket must exist, prefix will be created
+S3_BUCKET ?= "s4c-cft"
+S3_PREFIX ?= "test"
+# We need the REGION or the TemplateURLs might be created for a different region, resulting in a deployment error
+S3_REGION ?= "eu-west-1" # ireland
+SECURE_API_TOKEN ?= ""
+STACK_NAME = "CSPMCloudlogsFullInstall"
+STACK_NAME_ORG = "CSPMCloudlogsOrgFullInstall"
+
+.PHONY: packaged-template.yaml
+.PHONY: packaged-template-org.yaml
+
+validate:
+	aws cloudformation validate-template --template-body file://./FullInstall.yaml
+	aws cloudformation validate-template --template-body file://./OrgFullInstall.yaml
+
+lint:
+	cfn-lint *.yaml
+
+packaged-template.yaml:
+	aws s3 rm s3://$(S3_BUCKET)/full-install/single/$(S3_PREFIX) --recursive
+	aws cloudformation package \
+		--region $(S3_REGION) \
+		--template-file FullInstall.yaml \
+		--s3-bucket $(S3_BUCKET) \
+		--s3-prefix full-install/$(S3_PREFIX) \
+		--force-upload \
+		--output-template-file packaged-template.yaml
+
+test: packaged-template.yaml
+	aws cloudformation deploy \
+		--stack-name $(STACK_NAME) \
+		--template-file packaged-template.yaml \
+		--capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" \
+		--parameter-overrides \
+			"SysdigSecureAPIToken=$(SECURE_API_TOKEN)"
+
+ci: packaged-template.yaml
+	aws s3 cp ./packaged-template.yaml s3://$(S3_BUCKET)/full-install/single/$(S3_PREFIX)/entry-point.yaml
+
+clean:
+	aws cloudformation delete-stack --stack-name $(STACK_NAME)
+
+packaged-template-org.yaml:
+	aws s3 rm s3://$(S3_BUCKET)/full-install/org/$(S3_PREFIX) --recursive
+	aws cloudformation package \
+		--region $(S3_REGION) \
+		--template-file OrgFullInstall.yaml \
+		--s3-bucket $(S3_BUCKET) \
+		--s3-prefix full-install/$(S3_PREFIX) \
+		--force-upload \
+		--output-template-file packaged-template-org.yaml
+
+test-org: packaged-template-org.yaml
+	aws cloudformation deploy \
+		--stack-name $(STACK_NAME_ORG) \
+		--template-file packaged-template-org.yaml \
+		--capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" \
+		--parameter-overrides \
+			"SysdigSecureAPIToken=$(SECURE_API_TOKEN)"
+
+ci-org: packaged-template-org.yaml
+	aws s3 cp ./packaged-template-org.yaml s3://$(S3_BUCKET)/full-install/org/$(S3_PREFIX)/entry-point.yaml
+
+clean-org:
+	aws cloudformation delete-stack --stack-name $(STACK_NAME_ORG)

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -1,0 +1,194 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: IAM Role and EventBridge resources used by Sysdig Secure
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Sysdig Settings (Do not change)"
+        Parameters:
+          - CSPMRoleName
+          - ExternalID
+          - TrustedIdentity
+          - BucketARN
+          - Regions
+          - OrganizationUnitIDs
+
+    ParameterLabels:
+      CSPMRoleName:
+        default: "CSPM Role Name (Sysdig use only)"
+      CloudLogsRoleName:
+        default: "CloudLogs Role Name (Sysdig use only)"
+      ExternalID:
+        default: "External ID (Sysdig use only)"
+      BucketARN:
+        default: "Bucket ARN"
+      TrustedIdentity:
+        default: "Trusted Identity (Sysdig use only)"
+      OrganizationUnitIDs:
+        default: "Organization Unit IDs (Sysdig use only)"
+
+Parameters:
+  CSPMRoleName:
+    Type: String
+    Description: The read-only IAM Role that Sysdig will create
+  CloudLogsRoleName:
+    Type: String
+    Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
+  ExternalID:
+    Type: String
+    Description: Sysdig ExternalID required for the policy creation
+  BucketARN:
+    Type: String
+    Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+  TrustedIdentity:
+    Type: String
+    Description: The Role in Sysdig's AWS Account with permissions to your account
+  OrganizationUnitIDs:
+    Type: String
+    Description: Organization Unit IDs to deploy
+
+Resources:
+  CloudAgentlessRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub ${CSPMRoleName}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub ${TrustedIdentity}
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Sub ${ExternalID}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/SecurityAudit
+  CloudLogsRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref CloudLogsRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref TrustedIdentity
+            Action:
+              - "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ExternalId
+  CloudLogsRolePolicies:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "CloudlogsS3Access"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "CloudlogsS3Access"
+            Effect: "Allow"
+            Action:
+              - "s3:Get*"
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}'
+              - !Sub '${BucketARN}/*'
+      Roles:
+        - Ref: "CloudLogs"
+  RolesStackSet:
+    Type: AWS::CloudFormation::StackSet
+    Properties:
+      StackSetName: RolesStackSet
+      Description: IAM Role used to forward CloudTrail logs to Sysdig Secure
+      PermissionModel: SERVICE_MANAGED
+      Capabilities:
+        - "CAPABILITY_NAMED_IAM"
+      AutoDeployment:
+        Enabled: false
+      OperationPreferences:
+        MaxConcurrentCount: 5
+      Parameters:
+        - ParameterKey: CSPMRoleName
+          ParameterValue: !Ref CSPMRoleName
+        - ParameterKey: CloudLogsRoleName
+          ParameterValue: !Ref CloudLogsRoleName
+        - ParameterKey: TrustedIdentity
+          ParameterValue: !Ref TrustedIdentity
+        - ParameterKey: ExternalID
+          ParameterValue: !Ref ExternalID
+        - ParameterKey: BucketARN
+          ParameterValue: !Ref BucketARN
+      StackInstancesGroup:
+        - DeploymentTargets:
+            OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
+          Regions: [!Ref "AWS::Region"]
+      TemplateBody: |
+        AWSTemplateFormatVersion: "2010-09-09"
+        Description: IAM Role used to forward CloudTrail logs to Sysdig Secure
+        Parameters:
+          CSPMRoleName:
+            Type: String
+            Description: A unique identifier used to create an IAM Role and EventBridge Rule
+          CloudLogsRoleName:
+            Type: String
+            Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
+          TrustedIdentity:
+            Type: String
+            Description: The Role in Sysdig's AWS Account with permissions to your account
+          BucketARN:
+            Type: String
+            Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+          ExternalID:
+            Type: String
+            Description: Sysdig ExternalID required for the policy creation
+        Resources:
+          CloudAgentlessRole:
+            Type: "AWS::IAM::Role"
+            Properties:
+              RoleName: !Sub ${CSPMRoleName}
+              AssumeRolePolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: "Allow"
+                    Principal:
+                      AWS: !Sub ${TrustedIdentity}
+                    Action: "sts:AssumeRole"
+                    Condition:
+                      StringEquals:
+                        sts:ExternalId: !Sub ${ExternalID}
+              ManagedPolicyArns:
+                - arn:aws:iam::aws:policy/SecurityAudit
+          CloudLogsRole:
+            Type: "AWS::IAM::Role"
+            Properties:
+              RoleName: !Ref CloudLogsRoleName
+              AssumeRolePolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: "Allow"
+                    Principal:
+                      AWS: !Ref TrustedIdentity
+                    Action:
+                      - "sts:AssumeRole"
+                    Condition:
+                      StringEquals:
+                        "sts:ExternalId": !Ref ExternalId
+          CloudLogsRolePolicies:
+            Type: "AWS::IAM::Policy"
+            Properties:
+              PolicyName: "CloudlogsS3Access"
+              PolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  - Sid: "CloudlogsS3Access"
+                    Effect: "Allow"
+                    Action:
+                      - "s3:Get*"
+                      - "s3:List*"
+                    Resource:
+                      - !Sub '${BucketARN}'
+                      - !Sub '${BucketARN}/*'
+              Roles:
+                - Ref: "CloudLogs"

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: IAM Role and EventBridge resources used by Sysdig Secure
+Description: IAM Role and Cloudlogs resources used by Sysdig Secure
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -8,10 +8,9 @@ Metadata:
           default: "Sysdig Settings (Do not change)"
         Parameters:
           - CSPMRoleName
-          - ExternalID
+          - ExternalId
           - TrustedIdentity
           - BucketARN
-          - Regions
           - OrganizationUnitIDs
 
     ParameterLabels:
@@ -19,7 +18,7 @@ Metadata:
         default: "CSPM Role Name (Sysdig use only)"
       CloudLogsRoleName:
         default: "CloudLogs Role Name (Sysdig use only)"
-      ExternalID:
+      ExternalId:
         default: "External ID (Sysdig use only)"
       BucketARN:
         default: "Bucket ARN"
@@ -35,7 +34,7 @@ Parameters:
   CloudLogsRoleName:
     Type: String
     Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
-  ExternalID:
+  ExternalId:
     Type: String
     Description: Sysdig ExternalID required for the policy creation
   BucketARN:
@@ -62,7 +61,7 @@ Resources:
             Action: "sts:AssumeRole"
             Condition:
               StringEquals:
-                sts:ExternalId: !Sub ${ExternalID}
+                sts:ExternalId: !Sub ${ExternalId}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/SecurityAudit
   CloudLogsRole:
@@ -96,7 +95,7 @@ Resources:
               - !Sub '${BucketARN}'
               - !Sub '${BucketARN}/*'
       Roles:
-        - Ref: "CloudLogs"
+        - Ref: "CloudLogsRole"
   RolesStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
@@ -116,8 +115,8 @@ Resources:
           ParameterValue: !Ref CloudLogsRoleName
         - ParameterKey: TrustedIdentity
           ParameterValue: !Ref TrustedIdentity
-        - ParameterKey: ExternalID
-          ParameterValue: !Ref ExternalID
+        - ParameterKey: ExternalId
+          ParameterValue: !Ref ExternalId
         - ParameterKey: BucketARN
           ParameterValue: !Ref BucketARN
       StackInstancesGroup:
@@ -130,7 +129,7 @@ Resources:
         Parameters:
           CSPMRoleName:
             Type: String
-            Description: A unique identifier used to create an IAM Role and EventBridge Rule
+            Description: A unique identifier used to create an IAM Role
           CloudLogsRoleName:
             Type: String
             Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
@@ -140,7 +139,7 @@ Resources:
           BucketARN:
             Type: String
             Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
-          ExternalID:
+          ExternalId:
             Type: String
             Description: Sysdig ExternalID required for the policy creation
         Resources:
@@ -157,7 +156,7 @@ Resources:
                     Action: "sts:AssumeRole"
                     Condition:
                       StringEquals:
-                        sts:ExternalId: !Sub ${ExternalID}
+                        sts:ExternalId: !Sub ${ExternalId}
               ManagedPolicyArns:
                 - arn:aws:iam::aws:policy/SecurityAudit
           CloudLogsRole:
@@ -191,4 +190,4 @@ Resources:
                       - !Sub '${BucketARN}'
                       - !Sub '${BucketARN}/*'
               Roles:
-                - Ref: "CloudLogs"
+                - Ref: "CloudLogsRole"


### PR DESCRIPTION
Add the `cloudlogs` module for AWS onboarding. The template provisions a dedicated role to be assumed by Sysdig's trusted identity that has `Get` and `List` permissions on a CloudTrail-backed S3 bucket. 

The corresponding `terraform` implementation can be found [here](https://github.com/draios/terraform-aws-secure-for-cloud/tree/main/modules/services/cloud-logs). 

**Note for the reviewers**: In the `CloudLogs` single case only one template is needed for both the `single` and `org` cases, that's why the s3 path in the `Makefile` does not use the `/single/` component on the file keys. Please let me know if I've missed anything or if you prefer other conventions!