### PR TITLE
Revamp cloudformation templates for Cloudlogs module

### DIFF
--- a/templates_cloudlogs/CloudLogs.yaml
+++ b/templates_cloudlogs/CloudLogs.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  CloudFormation template for provisioning
+  CloudFormation single template for provisioning
   the necessary resources for the `cloud-logs`
   component.
 

--- a/templates_cloudlogs/Makefile
+++ b/templates_cloudlogs/Makefile
@@ -5,18 +5,21 @@ S3_PREFIX ?= "test"
 # We need the REGION or the TemplateURLs might be created for a different region, resulting in a deployment error
 S3_REGION ?= "eu-west-1" # ireland
 SECURE_API_TOKEN ?= ""
-STACK_NAME = "CloudLogsTest"
+STACK_NAME = "CloudlogsTest"
+STACK_NAME_ORG = "OrgCloudlogsTest"
 
 .PHONY: packaged-template.yaml
+.PHONY: packaged-template-org.yaml
 
 validate:
 	aws cloudformation validate-template --template-body file://./CloudLogs.yaml
+	aws cloudformation validate-template --template-body file://./OrgCloudLogs.yaml
 
 lint:
 	cfn-lint *.yaml
 
 packaged-template.yaml:
-	aws s3 rm s3://$(S3_BUCKET)/cloudlogs/$(S3_PREFIX) --recursive
+	aws s3 rm s3://$(S3_BUCKET)/cloudlogs/single/$(S3_PREFIX) --recursive
 
 	aws cloudformation package \
 		--region $(S3_REGION) \
@@ -35,7 +38,31 @@ test: packaged-template.yaml
 			"SysdigSecureAPIToken=$(SECURE_API_TOKEN)"
 
 ci: packaged-template.yaml
-	aws s3 cp ./packaged-template.yaml s3://$(S3_BUCKET)/cloudlogs/$(S3_PREFIX)/entry-point.yaml
+	aws s3 cp ./packaged-template.yaml s3://$(S3_BUCKET)/cloudlogs/single/$(S3_PREFIX)/entry-point.yaml
 
 clean:
 	aws cloudformation delete-stack --stack-name $(STACK_NAME)
+
+packaged-template-org.yaml:
+	aws s3 rm s3://$(S3_BUCKET)/cloudlogs/org/$(S3_PREFIX) --recursive
+	aws cloudformation package \
+		--region $(S3_REGION) \
+		--template-file OrgCloudlogs.yaml \
+		--s3-bucket $(S3_BUCKET) \
+		--s3-prefix cspm/$(S3_PREFIX) \
+		--force-upload \
+		--output-template-file packaged-template-org.yaml
+
+test-org: packaged-template-org.yaml
+	aws cloudformation deploy \
+		--stack-name $(STACK_NAME_ORG) \
+		--template-file packaged-template-org.yaml \
+		--capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" \
+		--parameter-overrides \
+			"SysdigSecureAPIToken=$(SECURE_API_TOKEN)"
+
+ci-org: packaged-template-org.yaml
+	aws s3 cp ./packaged-template-org.yaml s3://$(S3_BUCKET)/cloudlogs/org/$(S3_PREFIX)/entry-point.yaml
+
+clean-org:
+	aws cloudformation delete-stack --stack-name $(STACK_NAME_ORG)

--- a/templates_cloudlogs/OrgCloudLogs.yaml
+++ b/templates_cloudlogs/OrgCloudLogs.yaml
@@ -1,8 +1,9 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  CloudFormation template for provisioning
+  CloudFormation organizational template for provisioning
   the necessary resources for the `cloud-logs`
-  component.
+  component and the read-only role required to itneract with
+  the target organizational environment.
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -10,14 +11,17 @@ Metadata:
       - Label:
           default: "Sysdig Settings (Do not change)"
         Parameters:
+          - CSPMRoleName
           - CloudLogsRoleName
           - ExternalId
           - TrustedIdentity
           - BucketARN
 
     ParameterLabels:
+      CSPMRoleName:
+        default: "CSPM Role Name (Sysdig use only)"
       CloudLogsRoleName:
-        default: "Role Name (Sysdig use only)"
+        default: "CloudLogs Role Name (Sysdig use only)"
       ExternalId:
         default: "External ID (Sysdig use only)"
       TrustedIdentity:
@@ -26,6 +30,9 @@ Metadata:
         default: "Bucket ARN"
 
 Parameters:
+  CSPMRoleName:
+    Type: String
+    Description: The name of the read-only IAM Role that Sysdig will use to interact with the target environment
   CloudLogsRoleName:
     Type: String
     Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
@@ -72,3 +79,19 @@ Resources:
               - !Sub '${BucketARN}/*'
       Roles:
         - Ref: "CloudLogsRole"
+  CloudAgentlessRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref CSPMRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref TrustedIdentity
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/SecurityAudit

--- a/templates_cloudlogs/OrgCloudLogs.yaml
+++ b/templates_cloudlogs/OrgCloudLogs.yaml
@@ -13,7 +13,7 @@ Metadata:
         Parameters:
           - CSPMRoleName
           - CloudLogsRoleName
-          - ExternalId
+          - ExternalID
           - TrustedIdentity
           - BucketARN
 
@@ -22,7 +22,7 @@ Metadata:
         default: "CSPM Role Name (Sysdig use only)"
       CloudLogsRoleName:
         default: "CloudLogs Role Name (Sysdig use only)"
-      ExternalId:
+      ExternalID:
         default: "External ID (Sysdig use only)"
       TrustedIdentity:
         default: "Trusted Identity (Sysdig use only)"
@@ -36,7 +36,7 @@ Parameters:
   CloudLogsRoleName:
     Type: String
     Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
-  ExternalId:
+  ExternalID:
     Type: String
     Description: Random string generated unique to a customer.
   TrustedIdentity:
@@ -61,7 +61,7 @@ Resources:
               - "sts:AssumeRole"
             Condition:
               StringEquals:
-                "sts:ExternalId": !Ref ExternalId
+                "sts:ExternalId": !Ref ExternalID
   CloudLogsRolePolicies:
     Type: "AWS::IAM::Policy"
     Properties:
@@ -92,6 +92,6 @@ Resources:
             Action: "sts:AssumeRole"
             Condition:
               StringEquals:
-                sts:ExternalId: !Ref ExternalId
+                sts:ExternalId: !Ref ExternalID
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/SecurityAudit

--- a/templates_cloudlogs/OrgCloudLogs.yaml
+++ b/templates_cloudlogs/OrgCloudLogs.yaml
@@ -1,0 +1,74 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudFormation template for provisioning
+  the necessary resources for the `cloud-logs`
+  component.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Sysdig Settings (Do not change)"
+        Parameters:
+          - CloudLogsRoleName
+          - ExternalId
+          - TrustedIdentity
+          - BucketARN
+
+    ParameterLabels:
+      CloudLogsRoleName:
+        default: "Role Name (Sysdig use only)"
+      ExternalId:
+        default: "External ID (Sysdig use only)"
+      TrustedIdentity:
+        default: "Trusted Identity (Sysdig use only)"
+      BucketARN:
+        default: "Bucket ARN"
+
+Parameters:
+  CloudLogsRoleName:
+    Type: String
+    Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
+  ExternalId:
+    Type: String
+    Description: Random string generated unique to a customer.
+  TrustedIdentity:
+    Type: String
+    Description: The name of Sysdig trusted identity.
+  BucketARN:
+    Type: String
+    Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+
+Resources:
+  CloudLogsRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref CloudLogsRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref TrustedIdentity
+            Action:
+              - "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ExternalId
+  CloudLogsRolePolicies:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "CloudlogsS3Access"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "CloudlogsS3Access"
+            Effect: "Allow"
+            Action:
+              - "s3:Get*"
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}'
+              - !Sub '${BucketARN}/*'
+      Roles:
+        - Ref: "CloudLogsRole"

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -112,14 +112,10 @@ Resources:
       Parameters:
         - ParameterKey: CSPMRoleName
           ParameterValue: !Ref CSPMRoleName
-        - ParameterKey: CloudLogsRoleName
-          ParameterValue: !Ref CloudLogsRoleName
         - ParameterKey: TrustedIdentity
           ParameterValue: !Ref TrustedIdentity
         - ParameterKey: ExternalID
           ParameterValue: !Ref ExternalID
-        - ParameterKey: BucketARN
-          ParameterValue: !Ref BucketARN
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
@@ -131,15 +127,9 @@ Resources:
           CSPMRoleName:
             Type: String
             Description: A unique identifier used to create an IAM Role
-          CloudLogsRoleName:
-            Type: String
-            Description: The name of the IAM Role that will enable access to the Cloudtrail logs.
           TrustedIdentity:
             Type: String
             Description: The Role in Sysdig's AWS Account with permissions to your account
-          BucketARN:
-            Type: String
-            Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
           ExternalID:
             Type: String
             Description: Sysdig ExternalID required for the policy creation
@@ -160,35 +150,3 @@ Resources:
                         sts:ExternalId: !Sub ${ExternalID}
               ManagedPolicyArns:
                 - arn:aws:iam::aws:policy/SecurityAudit
-          CloudLogsRole:
-            Type: "AWS::IAM::Role"
-            Properties:
-              RoleName: !Ref CloudLogsRoleName
-              AssumeRolePolicyDocument:
-                Version: "2012-10-17"
-                Statement:
-                  - Effect: "Allow"
-                    Principal:
-                      AWS: !Ref TrustedIdentity
-                    Action:
-                      - "sts:AssumeRole"
-                    Condition:
-                      StringEquals:
-                        "sts:ExternalId": !Ref ExternalID
-          CloudLogsRolePolicies:
-            Type: "AWS::IAM::Policy"
-            Properties:
-              PolicyName: "CloudlogsS3Access"
-              PolicyDocument:
-                Version: "2012-10-17"
-                Statement:
-                  - Sid: "CloudlogsS3Access"
-                    Effect: "Allow"
-                    Action:
-                      - "s3:Get*"
-                      - "s3:List*"
-                    Resource:
-                      - !Sub '${BucketARN}'
-                      - !Sub '${BucketARN}/*'
-              Roles:
-                - Ref: "CloudLogsRole"


### PR DESCRIPTION
Revamp `CloudLogs` templates in order to provision all the necessary resoruces to fully support the organizational case. Now the end result is the same as applying the alternative `terraform` module(s).
 
Note that, before this change, only one `CloudLogs` template was used for both the `Single` and `Organization` case, while an additional role needed to be provisioned in the `Organizational` case for Sysdig's systems to properly work. This means that also the `Makefile` taking care of publishing the templates has been updated accordingly, along with the necessary changes in Sysdig's backend.  
