### PR TITLE
Update cloudlogs workflow in order to publish org template

### DIFF
--- a/.github/workflows/ci-master-cloudlogs.yaml
+++ b/.github/workflows/ci-master-cloudlogs.yaml
@@ -31,3 +31,9 @@ jobs:
         S3_BUCKET: cf-templates-cloudvision-ci
         S3_PREFIX: master
 
+    - name: Build and Upload Cloudlogs Org templates
+      run: make ci-org
+      working-directory: ./templates_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: master

--- a/.github/workflows/ci-pull-request-cloudlogs.yaml
+++ b/.github/workflows/ci-pull-request-cloudlogs.yaml
@@ -46,3 +46,10 @@ jobs:
       env:
         S3_BUCKET: cf-templates-cloudvision-ci
         S3_PREFIX: pr/${{ github.event.pull_request.head.ref }}
+
+    - name: Build and Upload Cloudlogs Org Templates
+      run: make ci-org
+      working-directory: templates_cloudlogs
+      env:
+        S3_BUCKET: cf-templates-cloudvision-ci
+        S3_PREFIX: pr/${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Add `ci-org` build step in `ci-master-cloudlogs.yml` and `ci-pull-request-cloudlogs.yml`