### PR TITLE
Update S3 access policy in cloudlogs-related templates

### DIFF
--- a/templates_cloudlogs/CloudLogs.yaml
+++ b/templates_cloudlogs/CloudLogs.yaml
@@ -14,6 +14,7 @@ Metadata:
           - ExternalID
           - TrustedIdentity
           - BucketARN
+          - AccountID
 
     ParameterLabels:
       CloudLogsRoleName:
@@ -24,6 +25,8 @@ Metadata:
         default: "Trusted Identity (Sysdig use only)"
       BucketARN:
         default: "Bucket ARN"
+      AccountID:
+        default: "Account ID"
 
 Parameters:
   CloudLogsRoleName:
@@ -38,6 +41,9 @@ Parameters:
   BucketARN:
     Type: String
     Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+  AccountID:
+    Type: String
+    Description: The Identifier of your AWS account.
 
 Resources:
   CloudLogsRole:
@@ -62,13 +68,19 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: "CloudlogsS3Access"
+          - Sid: "CloudlogsS3AccessGet"
             Effect: "Allow"
             Action:
               - "s3:Get*"
-              - "s3:List*"
             Resource:
               - !Sub '${BucketARN}'
               - !Sub '${BucketARN}/*'
+          - Sid: "CloudlogsS3AccessList"
+            Effect: "Allow"
+            Action:
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}'
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}/*'
       Roles:
         - Ref: "CloudLogsRole"

--- a/templates_cloudlogs/Makefile
+++ b/templates_cloudlogs/Makefile
@@ -47,7 +47,7 @@ packaged-template-org.yaml:
 	aws s3 rm s3://$(S3_BUCKET)/cloudlogs/org/$(S3_PREFIX) --recursive
 	aws cloudformation package \
 		--region $(S3_REGION) \
-		--template-file OrgCloudlogs.yaml \
+		--template-file OrgCloudLogs.yaml \
 		--s3-bucket $(S3_BUCKET) \
 		--s3-prefix cspm/$(S3_PREFIX) \
 		--force-upload \

--- a/templates_cloudlogs/OrgCloudLogs.yaml
+++ b/templates_cloudlogs/OrgCloudLogs.yaml
@@ -16,6 +16,7 @@ Metadata:
           - ExternalID
           - TrustedIdentity
           - BucketARN
+          - AccountID
 
     ParameterLabels:
       CSPMRoleName:
@@ -28,6 +29,8 @@ Metadata:
         default: "Trusted Identity (Sysdig use only)"
       BucketARN:
         default: "Bucket ARN"
+      AccountID:
+        default: "Account ID"
 
 Parameters:
   CSPMRoleName:
@@ -45,6 +48,9 @@ Parameters:
   BucketARN:
     Type: String
     Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+  AccountID:
+    Type: String
+    Description: The Identifier of your AWS account.
 
 Resources:
   CloudLogsRole:
@@ -69,14 +75,20 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: "CloudlogsS3Access"
+          - Sid: "CloudlogsS3AccessGet"
             Effect: "Allow"
             Action:
               - "s3:Get*"
-              - "s3:List*"
             Resource:
               - !Sub '${BucketARN}'
               - !Sub '${BucketARN}/*'
+          - Sid: "CloudlogsS3AccessList"
+            Effect: "Allow"
+            Action:
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}'
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}/*'
       Roles:
         - Ref: "CloudLogsRole"
   CloudAgentlessRole:

--- a/templates_cspm_cloudlogs/FullInstall.yaml
+++ b/templates_cspm_cloudlogs/FullInstall.yaml
@@ -12,6 +12,7 @@ Metadata:
           - ExternalID
           - TrustedIdentity
           - BucketARN
+          - AccountID
 
     ParameterLabels:
       CSPMRoleName:
@@ -24,6 +25,8 @@ Metadata:
         default: "Trusted Identity (Sysdig use only)"
       BucketARN:
         default: "Bucket ARN"
+      AccountID:
+        default: "Account ID"
 
 Parameters:
   CSPMRoleName:
@@ -41,6 +44,9 @@ Parameters:
   BucketARN:
     Type: String
     Description: The ARN of your s3 bucket associated with your Cloudtrail trail.
+  AccountID:
+    Type: String
+    Description: The Identifier of your AWS account.
 
 Resources:
   CloudAgentlessRole:
@@ -82,13 +88,19 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: "CloudlogsS3Access"
+          - Sid: "CloudlogsS3AccessGet"
             Effect: "Allow"
             Action:
               - "s3:Get*"
-              - "s3:List*"
             Resource:
               - !Sub '${BucketARN}'
               - !Sub '${BucketARN}/*'
+          - Sid: "CloudlogsS3AccessList"
+            Effect: "Allow"
+            Action:
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}'
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}/*'
       Roles:
         - Ref: "CloudLogsRole"

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -13,6 +13,7 @@ Metadata:
           - TrustedIdentity
           - BucketARN
           - OrganizationUnitIDs
+          - AccountID
 
     ParameterLabels:
       CSPMRoleName:
@@ -27,6 +28,8 @@ Metadata:
         default: "Trusted Identity (Sysdig use only)"
       OrganizationUnitIDs:
         default: "Organization Unit IDs (Sysdig use only)"
+      AccountID:
+        default: "Account ID"
 
 Parameters:
   CSPMRoleName:
@@ -47,6 +50,9 @@ Parameters:
   OrganizationUnitIDs:
     Type: String
     Description: Organization Unit IDs to deploy
+  AccountID:
+    Type: String
+    Description: The Identifier of your AWS account.
 
 Resources:
   CloudAgentlessRole:
@@ -87,14 +93,20 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: "CloudlogsS3Access"
+          - Sid: "CloudlogsS3AccessGet"
             Effect: "Allow"
             Action:
               - "s3:Get*"
-              - "s3:List*"
             Resource:
               - !Sub '${BucketARN}'
               - !Sub '${BucketARN}/*'
+          - Sid: "CloudlogsS3AccessList"
+            Effect: "Allow"
+            Action:
+              - "s3:List*"
+            Resource:
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}'
+              - !Sub '${BucketARN}/AWSLogs/${AccountID}/*'
       Roles:
         - Ref: "CloudLogsRole"
   RolesStackSet:


### PR DESCRIPTION
The update to the S3 policy is necessary to properly access the audit logs stored in S3 covering all the corner cases. 