### PR TITLE
fix(eventbridge): Add permissions to describe rule and targets to CFTs

### DIFF
--- a/templates_cspm_eventbridge/FullInstall.yaml
+++ b/templates_cspm_eventbridge/FullInstall.yaml
@@ -97,6 +97,12 @@ Resources:
               - Effect: Allow
                 Action: 'events:PutEvents'
                 Resource: !Ref EventBusARN
+              - Effect: Allow
+                Action:
+                  - "events:DescribeRule"
+                  - "events:ListTargetsByRule"
+                Resource:
+                  - !Sub arn:aws:events:*:*:rule/${EventBridgeRoleName}
   EventBridgeRule:
     Type: AWS::Events::Rule
     Properties:

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -142,6 +142,12 @@ Resources:
               - Effect: Allow
                 Action: 'events:PutEvents'
                 Resource: !Sub ${EventBusARN}
+              - Effect: Allow
+                Action:
+                  - "events:DescribeRule"
+                  - "events:ListTargetsByRule"
+                Resource:
+                  - !Sub arn:aws:events:*:*:rule/${EventBridgeRoleName}
   RolesStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
@@ -231,6 +237,12 @@ Resources:
                       - Effect: Allow
                         Action: 'events:PutEvents'
                         Resource: !Sub ${EventBusARN}
+                      - Effect: Allow
+                        Action:
+                          - "events:DescribeRule"
+                          - "events:ListTargetsByRule"
+                        Resource:
+                          - !Sub arn:aws:events:*:*:rule/${EventBridgeRoleName}
   EBRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:

--- a/templates_eventbridge/EventBridge.yaml
+++ b/templates_eventbridge/EventBridge.yaml
@@ -72,6 +72,12 @@ Resources:
               - Effect: Allow
                 Action: 'events:PutEvents'
                 Resource: !Ref EventBusARN
+              - Effect: Allow
+                Action:
+                  - "events:DescribeRule"
+                  - "events:ListTargetsByRule"
+                Resource:
+                  - !Sub arn:aws:events:*:*:rule/${EventBridgeRoleName}
   EventBridgeRule:
     Type: AWS::Events::Rule
     Properties:

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -142,6 +142,12 @@ Resources:
               - Effect: Allow
                 Action: 'events:PutEvents'
                 Resource: !Sub ${EventBusARN}
+              - Effect: Allow
+                Action:
+                  - "events:DescribeRule"
+                  - "events:ListTargetsByRule"
+                Resource:
+                  - !Sub arn:aws:events:*:*:rule/${EventBridgeRoleName}
   MgmtAccEBRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Metadata:
@@ -275,6 +281,12 @@ Resources:
                       - Effect: Allow
                         Action: 'events:PutEvents'
                         Resource: !Sub ${EventBusARN}
+                      - Effect: Allow
+                        Action:
+                          - "events:DescribeRule"
+                          - "events:ListTargetsByRule"
+                        Resource:
+                          - !Sub arn:aws:events:*:*:rule/${EventBridgeRoleName}
   EBRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:


### PR DESCRIPTION
Adding the following permissions to EB role to be able to run thorough validations. These permissions are read-only and targetted to only specific EB rule resource created by the same CFT template :-
- events:DescribeRule
- events:ListTargetsByRule

Note:
- Fixing this for both single and org onboarding case.
- Validated the CFT templates using make validate.