### PR TITLE
Update permissions in AWS trust-relationship CFT templates

### DIFF
--- a/templates_cspm/CloudAgentlessRole.yaml
+++ b/templates_cspm/CloudAgentlessRole.yaml
@@ -62,6 +62,9 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
+              - Effect: "Allow"
+                Action: "macie2:ListClassificationJobs"
+                Resource: "*"
 
 Outputs:
   RoleARN:

--- a/templates_cspm/CloudAgentlessRole.yaml
+++ b/templates_cspm/CloudAgentlessRole.yaml
@@ -62,9 +62,6 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
-              - Effect: "Allow"
-                Action: "account:GetContactInformation"
-                Resource: "*"
 
 Outputs:
   RoleARN:

--- a/templates_cspm/OrgCloudAgentlessRole.yaml
+++ b/templates_cspm/OrgCloudAgentlessRole.yaml
@@ -64,9 +64,6 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
-              - Effect: "Allow"
-                Action: "account:GetContactInformation"
-                Resource: "*"
   RoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
@@ -135,6 +132,3 @@ Resources:
                         Resource:
                           - "arn:aws:waf-regional:*:*:rule/*"
                           - "arn:aws:waf-regional:*:*:rulegroup/*"
-                      - Effect: "Allow"
-                        Action: "account:GetContactInformation"
-                        Resource: "*"

--- a/templates_cspm/OrgCloudAgentlessRole.yaml
+++ b/templates_cspm/OrgCloudAgentlessRole.yaml
@@ -64,6 +64,9 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
+              - Effect: "Allow"
+                Action: "macie2:ListClassificationJobs"
+                Resource: "*"
   RoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
@@ -132,3 +135,6 @@ Resources:
                         Resource:
                           - "arn:aws:waf-regional:*:*:rule/*"
                           - "arn:aws:waf-regional:*:*:rulegroup/*"
+                      - Effect: "Allow"
+                        Action: "macie2:ListClassificationJobs"
+                        Resource: "*"

--- a/templates_cspm_cloudlogs/FullInstall.yaml
+++ b/templates_cspm_cloudlogs/FullInstall.yaml
@@ -75,6 +75,9 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
+              - Effect: "Allow"
+                Action: "macie2:ListClassificationJobs"
+                Resource: "*"
   CloudLogsRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/templates_cspm_cloudlogs/FullInstall.yaml
+++ b/templates_cspm_cloudlogs/FullInstall.yaml
@@ -75,9 +75,6 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
-              - Effect: "Allow"
-                Action: "account:GetContactInformation"
-                Resource: "*"
   CloudLogsRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -80,9 +80,6 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
-              - Effect: "Allow"
-                Action: "account:GetContactInformation"
-                Resource: "*"
   CloudLogsRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -189,6 +186,3 @@ Resources:
                         Resource:
                           - "arn:aws:waf-regional:*:*:rule/*"
                           - "arn:aws:waf-regional:*:*:rulegroup/*"
-                      - Effect: "Allow"
-                        Action: "account:GetContactInformation"
-                        Resource: "*"

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -80,6 +80,9 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
+              - Effect: "Allow"
+                Action: "macie2:ListClassificationJobs"
+                Resource: "*"
   CloudLogsRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -186,3 +189,6 @@ Resources:
                         Resource:
                           - "arn:aws:waf-regional:*:*:rule/*"
                           - "arn:aws:waf-regional:*:*:rulegroup/*"
+                      - Effect: "Allow"
+                        Action: "macie2:ListClassificationJobs"
+                        Resource: "*"

--- a/templates_cspm_eventbridge/FullInstall.yaml
+++ b/templates_cspm_eventbridge/FullInstall.yaml
@@ -87,6 +87,9 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
+              - Effect: "Allow"
+                Action: "macie2:ListClassificationJobs"
+                Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:

--- a/templates_cspm_eventbridge/FullInstall.yaml
+++ b/templates_cspm_eventbridge/FullInstall.yaml
@@ -87,9 +87,6 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
-              - Effect: "Allow"
-                Action: "account:GetContactInformation"
-                Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -131,6 +131,9 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
+              - Effect: "Allow"
+                Action: "macie2:ListClassificationJobs"
+                Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
@@ -241,6 +244,9 @@ Resources:
                         Resource:
                           - "arn:aws:waf-regional:*:*:rule/*"
                           - "arn:aws:waf-regional:*:*:rulegroup/*"
+                      - Effect: "Allow"
+                        Action: "macie2:ListClassificationJobs"
+                        Resource: "*"
           EventBridgeRole:
             Type: AWS::IAM::Role
             Properties:

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -131,9 +131,6 @@ Resources:
                 Resource:
                   - "arn:aws:waf-regional:*:*:rule/*"
                   - "arn:aws:waf-regional:*:*:rulegroup/*"
-              - Effect: "Allow"
-                Action: "account:GetContactInformation"
-                Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
@@ -244,9 +241,6 @@ Resources:
                         Resource:
                           - "arn:aws:waf-regional:*:*:rule/*"
                           - "arn:aws:waf-regional:*:*:rulegroup/*"
-                      - Effect: "Allow"
-                        Action: "account:GetContactInformation"
-                        Resource: "*"
           EventBridgeRole:
             Type: AWS::IAM::Role
             Properties:


### PR DESCRIPTION
Removing `account:GetContactInformation` since it is no longer a required permission for the CSPM feature to work.
Adding `macie2:ListClassificationJobs` permission.