### PR TITLE
[SSPROD-40004] Adding permissions for aws-templates for the getFunction call

### DIFF
--- a/templates_cspm/CloudAgentlessRole.yaml
+++ b/templates_cspm/CloudAgentlessRole.yaml
@@ -66,10 +66,9 @@ Resources:
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "lambda:GetRuntimeManagementConfig"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "lambda:GetFunction"
+                Action:
+                  - "lambda:GetRuntimeManagementConfig"
+                  - "lambda:GetFunction"
                 Resource: "*"
 
 Outputs:

--- a/templates_cspm/CloudAgentlessRole.yaml
+++ b/templates_cspm/CloudAgentlessRole.yaml
@@ -68,6 +68,9 @@ Resources:
               - Effect: "Allow"
                 Action: "lambda:GetRuntimeManagementConfig"
                 Resource: "*"
+              - Effect: "Allow"
+                Action: "lambda:GetFunction"
+                Resource: "*"
 
 Outputs:
   RoleARN:

--- a/templates_cspm/OrgCloudAgentlessRole.yaml
+++ b/templates_cspm/OrgCloudAgentlessRole.yaml
@@ -68,10 +68,9 @@ Resources:
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "lambda:GetRuntimeManagementConfig"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "lambda:GetFunction"
+                Action:
+                  - "lambda:GetRuntimeManagementConfig"
+                  - "lambda:GetFunction"
                 Resource: "*"
   RoleStackSet:
     Type: AWS::CloudFormation::StackSet
@@ -145,8 +144,7 @@ Resources:
                         Action: "macie2:ListClassificationJobs"
                         Resource: "*"
                       - Effect: "Allow"
-                        Action: "lambda:GetRuntimeManagementConfig"
-                        Resource: "*"
-                      - Effect: "Allow"
-                        Action: "lambda:GetFunction"
+                        Action:
+                          - "lambda:GetRuntimeManagementConfig"
+                          - "lambda:GetFunction"
                         Resource: "*"

--- a/templates_cspm/OrgCloudAgentlessRole.yaml
+++ b/templates_cspm/OrgCloudAgentlessRole.yaml
@@ -70,6 +70,9 @@ Resources:
               - Effect: "Allow"
                 Action: "lambda:GetRuntimeManagementConfig"
                 Resource: "*"
+              - Effect: "Allow"
+                Action: "lambda:GetFunction"
+                Resource: "*"
   RoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
@@ -143,4 +146,7 @@ Resources:
                         Resource: "*"
                       - Effect: "Allow"
                         Action: "lambda:GetRuntimeManagementConfig"
+                        Resource: "*"
+                      - Effect: "Allow"
+                        Action: "lambda:GetFunction"
                         Resource: "*"

--- a/templates_cspm_cloudlogs/FullInstall.yaml
+++ b/templates_cspm_cloudlogs/FullInstall.yaml
@@ -81,6 +81,9 @@ Resources:
               - Effect: "Allow"
                 Action: "lambda:GetRuntimeManagementConfig"
                 Resource: "*"
+              - Effect: "Allow"
+                Action: "lambda:GetFunction"
+                Resource: "*"
   CloudLogsRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/templates_cspm_cloudlogs/FullInstall.yaml
+++ b/templates_cspm_cloudlogs/FullInstall.yaml
@@ -79,10 +79,9 @@ Resources:
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "lambda:GetRuntimeManagementConfig"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "lambda:GetFunction"
+                Action:
+                  - "lambda:GetRuntimeManagementConfig"
+                  - "lambda:GetFunction"
                 Resource: "*"
   CloudLogsRole:
     Type: "AWS::IAM::Role"

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -84,7 +84,9 @@ Resources:
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "lambda:GetRuntimeManagementConfig"
+                Action:
+                  - "lambda:GetRuntimeManagementConfig"
+                  - "lambda:GetFunction"
                 Resource: "*"
   CloudLogsRole:
     Type: "AWS::IAM::Role"
@@ -196,8 +198,7 @@ Resources:
                         Action: "macie2:ListClassificationJobs"
                         Resource: "*"
                       - Effect: "Allow"
-                        Action: "lambda:GetRuntimeManagementConfig"
-                        Resource: "*"
-                      - Effect: "Allow"
-                        Action: "lambda:GetFunction"
+                        Action:
+                          - "lambda:GetRuntimeManagementConfig"
+                          - "lambda:GetFunction"
                         Resource: "*"

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -198,3 +198,6 @@ Resources:
                       - Effect: "Allow"
                         Action: "lambda:GetRuntimeManagementConfig"
                         Resource: "*"
+                      - Effect: "Allow"
+                        Action: "lambda:GetFunction"
+                        Resource: "*"

--- a/templates_cspm_eventbridge/FullInstall.yaml
+++ b/templates_cspm_eventbridge/FullInstall.yaml
@@ -93,6 +93,9 @@ Resources:
               - Effect: "Allow"
                 Action: "lambda:GetRuntimeManagementConfig"
                 Resource: "*"
+              - Effect: "Allow"
+                Action: "lambda:GetFunction"
+                Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:

--- a/templates_cspm_eventbridge/FullInstall.yaml
+++ b/templates_cspm_eventbridge/FullInstall.yaml
@@ -91,10 +91,9 @@ Resources:
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "lambda:GetRuntimeManagementConfig"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "lambda:GetFunction"
+                Action:
+                  - "lambda:GetRuntimeManagementConfig"
+                  - "lambda:GetFunction"
                 Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -137,6 +137,9 @@ Resources:
               - Effect: "Allow"
                 Action: "lambda:GetRuntimeManagementConfig"
                 Resource: "*"
+              - Effect: "Allow"
+                Action: "lambda:GetFunction"
+                Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
@@ -252,6 +255,9 @@ Resources:
                         Resource: "*"
                       - Effect: "Allow"
                         Action: "lambda:GetRuntimeManagementConfig"
+                        Resource: "*"
+                      - Effect: "Allow"
+                        Action: "lambda:GetFunction"
                         Resource: "*"
           EventBridgeRole:
             Type: AWS::IAM::Role

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -135,10 +135,9 @@ Resources:
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "lambda:GetRuntimeManagementConfig"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "lambda:GetFunction"
+                Action:
+                  - "lambda:GetRuntimeManagementConfig"
+                  - "lambda:GetFunction"
                 Resource: "*"
   EventBridgeRole:
     Type: AWS::IAM::Role
@@ -254,10 +253,9 @@ Resources:
                         Action: "macie2:ListClassificationJobs"
                         Resource: "*"
                       - Effect: "Allow"
-                        Action: "lambda:GetRuntimeManagementConfig"
-                        Resource: "*"
-                      - Effect: "Allow"
-                        Action: "lambda:GetFunction"
+                        Action:
+                          - "lambda:GetRuntimeManagementConfig"
+                          - "lambda:GetFunction"
                         Resource: "*"
           EventBridgeRole:
             Type: AWS::IAM::Role


### PR DESCRIPTION
Adding permissions in order to obtain an aws lambda as docker image pull string which is only accessible through the GetFunction call (collector change incoming).