### PR TITLE
feat(event-bridge): add guardduty for event bridge, disabled by default (SSPROD-41990)

### DIFF
--- a/templates_cspm_eventbridge/FullInstall.yaml
+++ b/templates_cspm_eventbridge/FullInstall.yaml
@@ -13,6 +13,7 @@ Metadata:
           - EventBusARN
           - EventBridgeRoleName
           - EventBridgeState
+          - IncludeGuardDutyFindings
 
     ParameterLabels:
       RoleName:
@@ -27,7 +28,8 @@ Metadata:
         default: "Integration Name (Sysdig use only)"
       EventBridgeState:
         default: "State of the EventBridge Rule (Sysdig use only)"
-          
+      IncludeGuardDutyFindings:
+        default: "Include GuardDuty Findings"
        
 Parameters:
   RoleName:
@@ -53,6 +55,16 @@ Parameters:
       - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
       - ENABLED
       - DISABLED
+  IncludeGuardDutyFindings:
+    Type: String
+    Description: Whether to include GuardDuty findings in the EventBridge Rule
+    Default: 'DISABLED'
+    AllowedValues:
+      - 'ENABLED'
+      - 'DISABLED'
+
+Conditions:
+  IncludeGuardDuty: !Equals [ !Ref IncludeGuardDutyFindings, 'ENABLED' ]
 
 Resources:
   CloudAgentlessRole:
@@ -133,19 +145,37 @@ Resources:
       Description: Capture all CloudTrail events
       EventPattern:
         detail-type:
-          - 'AWS API Call via CloudTrail'
-          - 'AWS Console Sign In via CloudTrail'
-          - 'AWS Service Event via CloudTrail'
-          - 'Object Access Tier Changed'
-          - 'Object ACL Updated'
-          - 'Object Created'
-          - 'Object Deleted'
-          - 'Object Restore Completed'
-          - 'Object Restore Expired'
-          - 'Object Restore Initiated'
-          - 'Object Storage Class Changed'
-          - 'Object Tags Added'
-          - 'Object Tags Deleted'
+          !If 
+            - IncludeGuardDuty
+            - 
+              - 'AWS API Call via CloudTrail'
+              - 'AWS Console Sign In via CloudTrail'
+              - 'AWS Service Event via CloudTrail'
+              - 'Object Access Tier Changed'
+              - 'Object ACL Updated'
+              - 'Object Created'
+              - 'Object Deleted'
+              - 'Object Restore Completed'
+              - 'Object Restore Expired'
+              - 'Object Restore Initiated'
+              - 'Object Storage Class Changed'
+              - 'Object Tags Added'
+              - 'Object Tags Deleted'
+              - 'GuardDuty Finding'
+            - 
+              - 'AWS API Call via CloudTrail'
+              - 'AWS Console Sign In via CloudTrail'
+              - 'AWS Service Event via CloudTrail'
+              - 'Object Access Tier Changed'
+              - 'Object ACL Updated'
+              - 'Object Created'
+              - 'Object Deleted'
+              - 'Object Restore Completed'
+              - 'Object Restore Expired'
+              - 'Object Restore Initiated'
+              - 'Object Storage Class Changed'
+              - 'Object Tags Added'
+              - 'Object Tags Deleted'
       State: !Ref EventBridgeState
       Targets:
         - Id: !Ref EventBridgeRoleName

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -13,7 +13,8 @@ Metadata:
           - EventBusARN
           - Regions
           - OrganizationUnitIDs
-          - EventBridgeState
+          - EventBridgeState\
+          - IncludeGuardDutyFindings
     ParameterLabels:
       CSPMRoleName:
         default: "CSPM Role Name (Sysdig use only)"
@@ -31,6 +32,8 @@ Metadata:
         default: "Organization Unit IDs (Sysdig use only)"
       EventBridgeState:
         default: "State of the EventBridge Rule (Sysdig use only)"  
+      IncludeGuardDutyFindings:
+        default: "Include GuardDuty Findings"
 Parameters:
   CSPMRoleName:
     Type: String
@@ -61,7 +64,14 @@ Parameters:
       - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
       - ENABLED
       - DISABLED
-       
+  IncludeGuardDutyFindings:
+    Type: String
+    Description: Whether to include GuardDuty findings in the EventBridge Rule
+    Default: 'DISABLED'
+    AllowedValues:
+      - 'ENABLED'
+      - 'DISABLED'
+
 Resources:
   AdministrationRole:
     Type: AWS::IAM::Role
@@ -194,6 +204,8 @@ Resources:
           ParameterValue: !Ref EventBridgeRoleName
         - ParameterKey: EventBusARN
           ParameterValue: !Ref EventBusARN
+        - ParameterKey: IncludeGuardDutyFindings
+          ParameterValue: !Ref IncludeGuardDutyFindings
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds: !Split [ ",", !Ref OrganizationUnitIDs]
@@ -409,6 +421,8 @@ Resources:
           ParameterValue: !Ref EventBusARN
         - ParameterKey: EventBridgeState
           ParameterValue: !Ref EventBridgeState
+        - ParameterKey: IncludeGuardDutyFindings
+          ParameterValue: !Ref IncludeGuardDutyFindings
       StackInstancesGroup:
         - DeploymentTargets:
             Accounts:

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -329,7 +329,16 @@ Resources:
             AllowedValues:
               - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
               - ENABLED
-              - DISABLED                        
+              - DISABLED  
+          IncludeGuardDutyFindings:
+            Type: String
+            Description: Whether to include GuardDuty findings in the EventBridge Rule
+            Default: 'DISABLED'
+            AllowedValues:
+              - 'ENABLED'
+              - 'DISABLED'
+        Conditions:
+          IncludeGuardDuty: !Equals [ !Ref IncludeGuardDutyFindings, 'ENABLED' ]  
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -338,19 +347,37 @@ Resources:
               Description: Capture all CloudTrail events
               EventPattern:
                 detail-type:
-                  - 'AWS API Call via CloudTrail'
-                  - 'AWS Console Sign In via CloudTrail'
-                  - 'AWS Service Event via CloudTrail'
-                  - 'Object Access Tier Changed'
-                  - 'Object ACL Updated'
-                  - 'Object Created'
-                  - 'Object Deleted'
-                  - 'Object Restore Completed'
-                  - 'Object Restore Expired'
-                  - 'Object Restore Initiated'
-                  - 'Object Storage Class Changed'
-                  - 'Object Tags Added'
-                  - 'Object Tags Deleted'
+                  !If 
+                    - IncludeGuardDuty
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
+                      - 'GuardDuty Finding'
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
               State: !Sub ${EventBridgeState}
               Targets:
                 - Id: !Sub ${EventBridgeRoleName}
@@ -404,7 +431,16 @@ Resources:
             AllowedValues:
               - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
               - ENABLED
-              - DISABLED                     
+              - DISABLED   
+          IncludeGuardDutyFindings:
+            Type: String
+            Description: Whether to include GuardDuty findings in the EventBridge Rule
+            Default: 'DISABLED'
+            AllowedValues:
+              - 'ENABLED'
+              - 'DISABLED'
+        Conditions:
+          IncludeGuardDuty: !Equals [ !Ref IncludeGuardDutyFindings, 'ENABLED' ]     
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -413,19 +449,37 @@ Resources:
               Description: Capture all CloudTrail events
               EventPattern:
                 detail-type:
-                  - 'AWS API Call via CloudTrail'
-                  - 'AWS Console Sign In via CloudTrail'
-                  - 'AWS Service Event via CloudTrail'
-                  - 'Object Access Tier Changed'
-                  - 'Object ACL Updated'
-                  - 'Object Created'
-                  - 'Object Deleted'
-                  - 'Object Restore Completed'
-                  - 'Object Restore Expired'
-                  - 'Object Restore Initiated'
-                  - 'Object Storage Class Changed'
-                  - 'Object Tags Added'
-                  - 'Object Tags Deleted'
+                  !If 
+                    - IncludeGuardDuty
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
+                      - 'GuardDuty Finding'
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
               State: !Sub ${EventBridgeState}
               Targets:
                 - Id: !Sub ${EventBridgeRoleName}

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -13,7 +13,7 @@ Metadata:
           - EventBusARN
           - Regions
           - OrganizationUnitIDs
-          - EventBridgeState\
+          - EventBridgeState
           - IncludeGuardDutyFindings
     ParameterLabels:
       CSPMRoleName:

--- a/templates_eventbridge/EventBridge.yaml
+++ b/templates_eventbridge/EventBridge.yaml
@@ -11,6 +11,8 @@ Metadata:
           - ExternalID
           - TrustedIdentity
           - EventBusARN
+          - EventBridgeState
+          - IncludeGuardDutyFindings
 
     ParameterLabels:
       ExternalID:
@@ -23,6 +25,8 @@ Metadata:
         default: "Integration Name (Sysdig use only)"
       EventBridgeState:
         default: "State of the EventBridge Rule (Sysdig use only)"
+      IncludeGuardDutyFindings:
+        default: "Include GuardDuty Findings"
 
 Parameters:
   EventBridgeRoleName:

--- a/templates_eventbridge/EventBridge.yaml
+++ b/templates_eventbridge/EventBridge.yaml
@@ -45,6 +45,16 @@ Parameters:
       - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
       - ENABLED
       - DISABLED
+  IncludeGuardDutyFindings:
+    Type: String
+    Description: Whether to include GuardDuty findings in the EventBridge Rule
+    Default: 'DISABLED'
+    AllowedValues:
+      - 'ENABLED'
+      - 'DISABLED'
+
+Conditions:
+  IncludeGuardDuty: !Equals [ !Ref IncludeGuardDutyFindings, 'ENABLED' ]
 
 Resources:
   EventBridgeRole:
@@ -85,19 +95,37 @@ Resources:
       Description: Capture all CloudTrail events
       EventPattern:
         detail-type:
-          - 'AWS API Call via CloudTrail'
-          - 'AWS Console Sign In via CloudTrail'
-          - 'AWS Service Event via CloudTrail'
-          - 'Object Access Tier Changed'
-          - 'Object ACL Updated'
-          - 'Object Created'
-          - 'Object Deleted'
-          - 'Object Restore Completed'
-          - 'Object Restore Expired'
-          - 'Object Restore Initiated'
-          - 'Object Storage Class Changed'
-          - 'Object Tags Added'
-          - 'Object Tags Deleted'
+          !If 
+            - IncludeGuardDuty
+            - 
+              - 'AWS API Call via CloudTrail'
+              - 'AWS Console Sign In via CloudTrail'
+              - 'AWS Service Event via CloudTrail'
+              - 'Object Access Tier Changed'
+              - 'Object ACL Updated'
+              - 'Object Created'
+              - 'Object Deleted'
+              - 'Object Restore Completed'
+              - 'Object Restore Expired'
+              - 'Object Restore Initiated'
+              - 'Object Storage Class Changed'
+              - 'Object Tags Added'
+              - 'Object Tags Deleted'
+              - 'GuardDuty Finding'
+            - 
+              - 'AWS API Call via CloudTrail'
+              - 'AWS Console Sign In via CloudTrail'
+              - 'AWS Service Event via CloudTrail'
+              - 'Object Access Tier Changed'
+              - 'Object ACL Updated'
+              - 'Object Created'
+              - 'Object Deleted'
+              - 'Object Restore Completed'
+              - 'Object Restore Expired'
+              - 'Object Restore Initiated'
+              - 'Object Storage Class Changed'
+              - 'Object Tags Added'
+              - 'Object Tags Deleted'
       State: !Ref EventBridgeState
       Targets:
         - Id: !Ref EventBridgeRoleName

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -196,7 +196,16 @@ Resources:
             AllowedValues:
               - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
               - ENABLED
-              - DISABLED                         
+              - DISABLED   
+          IncludeGuardDutyFindings:
+            Type: String
+            Description: Whether to include GuardDuty findings in the EventBridge Rule
+            Default: 'DISABLED'
+            AllowedValues:
+              - 'ENABLED'
+              - 'DISABLED'
+        Conditions:
+          IncludeGuardDuty: !Equals [ !Ref IncludeGuardDutyFindings, 'ENABLED' ]
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -205,19 +214,37 @@ Resources:
               Description: Capture all CloudTrail events
               EventPattern:
                 detail-type:
-                  - 'AWS API Call via CloudTrail'
-                  - 'AWS Console Sign In via CloudTrail'
-                  - 'AWS Service Event via CloudTrail'
-                  - 'Object Access Tier Changed'
-                  - 'Object ACL Updated'
-                  - 'Object Created'
-                  - 'Object Deleted'
-                  - 'Object Restore Completed'
-                  - 'Object Restore Expired'
-                  - 'Object Restore Initiated'
-                  - 'Object Storage Class Changed'
-                  - 'Object Tags Added'
-                  - 'Object Tags Deleted'
+                  !If 
+                    - IncludeGuardDuty
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
+                      - 'GuardDuty Finding'
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
               State: !Sub ${EventBridgeState}
               Targets:
                 - Id: !Sub ${EventBridgeRoleName}
@@ -337,7 +364,16 @@ Resources:
             AllowedValues:
               - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
               - ENABLED
-              - DISABLED                 
+              - DISABLED   
+          IncludeGuardDutyFindings:
+            Type: String
+            Description: Whether to include GuardDuty findings in the EventBridge Rule
+            Default: 'DISABLED'
+            AllowedValues:
+              - 'ENABLED'
+              - 'DISABLED'
+        Conditions:
+          IncludeGuardDuty: !Equals [ !Ref IncludeGuardDutyFindings, 'ENABLED' ]              
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -346,19 +382,37 @@ Resources:
               Description: Capture all CloudTrail events
               EventPattern:
                 detail-type:
-                  - 'AWS API Call via CloudTrail'
-                  - 'AWS Console Sign In via CloudTrail'
-                  - 'AWS Service Event via CloudTrail'
-                  - 'Object Access Tier Changed'
-                  - 'Object ACL Updated'
-                  - 'Object Created'
-                  - 'Object Deleted'
-                  - 'Object Restore Completed'
-                  - 'Object Restore Expired'
-                  - 'Object Restore Initiated'
-                  - 'Object Storage Class Changed'
-                  - 'Object Tags Added'
-                  - 'Object Tags Deleted'
+                  !If 
+                    - IncludeGuardDuty
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
+                      - 'GuardDuty Finding'
+                    - 
+                      - 'AWS API Call via CloudTrail'
+                      - 'AWS Console Sign In via CloudTrail'
+                      - 'AWS Service Event via CloudTrail'
+                      - 'Object Access Tier Changed'
+                      - 'Object ACL Updated'
+                      - 'Object Created'
+                      - 'Object Deleted'
+                      - 'Object Restore Completed'
+                      - 'Object Restore Expired'
+                      - 'Object Restore Initiated'
+                      - 'Object Storage Class Changed'
+                      - 'Object Tags Added'
+                      - 'Object Tags Deleted'
               State: !Sub ${EventBridgeState}
               Targets:
                 - Id: !Sub ${EventBridgeRoleName}

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -14,6 +14,7 @@ Metadata:
           - Regions
           - OrganizationUnitIDs
           - EventBridgeState
+          - IncludeGuardDutyFindings
     ParameterLabels:
       CSPMRoleName:
         default: "CSPM Role Name (Sysdig use only)"    
@@ -31,6 +32,8 @@ Metadata:
         default: "Organization Unit IDs (Sysdig use only)"
       EventBridgeState:
         default: "State of the EventBridge Rule (Sysdig use only)"
+      IncludeGuardDutyFindings:
+        default: "Include GuardDuty Findings"
 Parameters:
   CSPMRoleName:
     Type: String
@@ -61,6 +64,13 @@ Parameters:
       - ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS
       - ENABLED
       - DISABLED
+  IncludeGuardDutyFindings:
+    Type: String
+    Description: Whether to include GuardDuty findings in the EventBridge Rule
+    Default: 'DISABLED'
+    AllowedValues:
+      - 'ENABLED'
+      - 'DISABLED'
 
 Resources:
   AdministrationRole:
@@ -173,7 +183,9 @@ Resources:
         - ParameterKey: EventBusARN
           ParameterValue: !Ref EventBusARN
         - ParameterKey: EventBridgeState
-          ParameterValue: !Ref EventBridgeState                     
+          ParameterValue: !Ref EventBridgeState
+        - ParameterKey: IncludeGuardDutyFindings
+          ParameterValue: !Ref IncludeGuardDutyFindings             
       StackInstancesGroup:
         - DeploymentTargets:
             Accounts: 


### PR DESCRIPTION
We are adding guardduty support in FalcoCloud detection, this will deploy a rule in the event bridge that will forward also the guardduty event to cloud ingestion