### PR TITLE
enabled stackset autodeployment

### DIFF
--- a/templates_cspm/OrgCloudAgentlessRole.yaml
+++ b/templates_cspm/OrgCloudAgentlessRole.yaml
@@ -81,7 +81,7 @@ Resources:
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
-        Enabled: false
+        Enabled: true
       Parameters:
         - ParameterKey: RoleName
           ParameterValue: !Ref RoleName

--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -135,7 +135,7 @@ Resources:
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
-        Enabled: false
+        Enabled: true
       OperationPreferences:
         MaxConcurrentCount: 5
       Parameters:

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -180,7 +180,7 @@ Resources:
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
-        Enabled: false
+        Enabled: true
       OperationPreferences:
         MaxConcurrentCount: 5
       Parameters:
@@ -298,7 +298,7 @@ Resources:
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
-        Enabled: false
+        Enabled: true
       OperationPreferences:
         MaxConcurrentCount: 5
       Parameters:

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -232,7 +232,7 @@ Resources:
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
-        Enabled: false
+        Enabled: true
       OperationPreferences:
         MaxConcurrentCount: 5
       Parameters:
@@ -306,7 +306,7 @@ Resources:
       Capabilities:
         - "CAPABILITY_NAMED_IAM"
       AutoDeployment:
-        Enabled: false
+        Enabled: true
       OperationPreferences:
         MaxConcurrentCount: 5
       Parameters:


### PR DESCRIPTION
Currently autodeployment is enabled in the CFT templates created by terraform https://github.com/draios/terraform-aws-secure-for-cloud/blob/c980db8ee098aed172c917b400da3ab5fbc0fce8/modules/services/event-bridge/organizational.tf#L26
Enabling autodeployment for consistency across solutions. This will allow the resources to be created when new AWS accounts are added in the Org.