### PR TITLE
Add region parallelism to stacksets

### DIFF
--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -143,7 +143,8 @@ Resources:
       ManagedExecution:
         Active: true
       OperationPreferences:
-        MaxConcurrentCount: 5
+        MaxConcurrentCount: 10
+        RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: CSPMRoleName
           ParameterValue: !Ref CSPMRoleName

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -215,7 +215,8 @@ Resources:
       ManagedExecution:
         Active: true
       OperationPreferences:
-        MaxConcurrentCount: 5
+        MaxConcurrentCount: 10
+        RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: CSPMRoleName
           ParameterValue: !Ref CSPMRoleName
@@ -339,7 +340,8 @@ Resources:
       ManagedExecution:
         Active: true
       OperationPreferences:
-        MaxConcurrentCount: 5
+        MaxConcurrentCount: 10
+        RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName
@@ -416,7 +418,8 @@ Resources:
       Capabilities:
         - CAPABILITY_NAMED_IAM
       OperationPreferences:
-        MaxConcurrentCount: 5
+        MaxConcurrentCount: 10
+        RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -193,7 +193,8 @@ Resources:
       Capabilities:
         - CAPABILITY_NAMED_IAM              
       OperationPreferences:
-        MaxConcurrentCount: 5
+        MaxConcurrentCount: 10
+        RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName
@@ -274,7 +275,8 @@ Resources:
       ManagedExecution:
         Active: true        
       OperationPreferences:
-        MaxConcurrentCount: 5
+        MaxConcurrentCount: 10
+        RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: TrustedIdentity
           ParameterValue: !Ref TrustedIdentity
@@ -351,7 +353,8 @@ Resources:
       ManagedExecution:
         Active: true        
       OperationPreferences:
-        MaxConcurrentCount: 5
+        MaxConcurrentCount: 10
+        RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName
           ParameterValue: !Ref EventBridgeRoleName


### PR DESCRIPTION
Add region parallelism to all stacksets. This was added in TF but missing in these CFTs.

Also set the default concurrency count to 10 to match the TF