### PR TITLE
Use 100% concurrency

### DIFF
--- a/templates_cspm_cloudlogs/OrgFullInstall.yaml
+++ b/templates_cspm_cloudlogs/OrgFullInstall.yaml
@@ -143,7 +143,8 @@ Resources:
       ManagedExecution:
         Active: true
       OperationPreferences:
-        MaxConcurrentCount: 10
+        MaxConcurrentPercentage: 100
+        ConcurrencyMode: SOFT_FAILURE_TOLERANCE
         RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: CSPMRoleName

--- a/templates_cspm_eventbridge/OrgFullInstall.yaml
+++ b/templates_cspm_eventbridge/OrgFullInstall.yaml
@@ -215,8 +215,8 @@ Resources:
       ManagedExecution:
         Active: true
       OperationPreferences:
-        MaxConcurrentCount: 10
-        RegionConcurrencyType: PARALLEL
+        MaxConcurrentPercentage: 100
+        ConcurrencyMode: SOFT_FAILURE_TOLERANCE
       Parameters:
         - ParameterKey: CSPMRoleName
           ParameterValue: !Ref CSPMRoleName
@@ -340,7 +340,8 @@ Resources:
       ManagedExecution:
         Active: true
       OperationPreferences:
-        MaxConcurrentCount: 10
+        MaxConcurrentPercentage: 100
+        ConcurrencyMode: SOFT_FAILURE_TOLERANCE
         RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName
@@ -418,7 +419,8 @@ Resources:
       Capabilities:
         - CAPABILITY_NAMED_IAM
       OperationPreferences:
-        MaxConcurrentCount: 10
+        MaxConcurrentPercentage: 100
+        ConcurrencyMode: SOFT_FAILURE_TOLERANCE
         RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName

--- a/templates_eventbridge/OrgEventBridge.yaml
+++ b/templates_eventbridge/OrgEventBridge.yaml
@@ -193,7 +193,8 @@ Resources:
       Capabilities:
         - CAPABILITY_NAMED_IAM              
       OperationPreferences:
-        MaxConcurrentCount: 10
+        MaxConcurrentPercentage: 100
+        ConcurrencyMode: SOFT_FAILURE_TOLERANCE
         RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName
@@ -275,8 +276,8 @@ Resources:
       ManagedExecution:
         Active: true        
       OperationPreferences:
-        MaxConcurrentCount: 10
-        RegionConcurrencyType: PARALLEL
+        MaxConcurrentPercentage: 100
+        ConcurrencyMode: SOFT_FAILURE_TOLERANCE
       Parameters:
         - ParameterKey: TrustedIdentity
           ParameterValue: !Ref TrustedIdentity
@@ -353,7 +354,8 @@ Resources:
       ManagedExecution:
         Active: true        
       OperationPreferences:
-        MaxConcurrentCount: 10
+        MaxConcurrentPercentage: 100
+        ConcurrencyMode: SOFT_FAILURE_TOLERANCE
         RegionConcurrencyType: PARALLEL
       Parameters:
         - ParameterKey: EventBridgeRoleName


### PR DESCRIPTION
For all stacksets, use:

- `MaxConcurrentPercentage: 100`
- `ConcurrencyMode: SOFT_FAILURE_TOLERANCE`

`FailureTolerancePercentage` is not set (and thus defaults to `0`) intentionally, and there are no downstream processes that are blocked by the CFT operation failing, and thus will give more visibility for failures without compromising the rest of the install experience.