### PR TITLE
feat(modules): Support for Govcloud account/org

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -45,7 +45,8 @@ deploy:
 			"ExternalID=$(PARAM_EXTERNAL_ID)" \
 			"TrustedIdentity=$(PARAM_TRUSTED_IDENTITY)" \
 			"IsOrganizational=$(PARAM_IS_ORGANIZATIONAL)" \
-			"OrganizationalUnitIDs=$(PARAM_ORGANIZATIONAL_UNIT_IDS)"
+			"OrganizationalUnitIDs=$(PARAM_ORGANIZATIONAL_UNIT_IDS)" \
+			"ARNPrefix=${PARAM_ARN_PREFIX}"
 	aws cloudformation deploy \
 		--stack-name $(STACK_NAME)-LogIngestion-EventBridge-$(PARAM_NAME_SUFFIX) \
 		--template-file log_ingestion.events.cft.yaml \
@@ -57,7 +58,8 @@ deploy:
 			"Regions=$(PARAM_REGIONS)" \
 			"TargetEventBusARN=$(PARAM_TARGET_EVENT_BUS_ARN)" \
 			"IsOrganizational=$(PARAM_IS_ORGANIZATIONAL)" \
-			"OrganizationalUnitIDs=$(PARAM_ORGANIZATIONAL_UNIT_IDS)"
+			"OrganizationalUnitIDs=$(PARAM_ORGANIZATIONAL_UNIT_IDS)" \
+			"ARNPrefix=${PARAM_ARN_PREFIX}"
 	aws cloudformation deploy \
 		--stack-name $(STACK_NAME)-LogIngestion-S3-$(PARAM_NAME_SUFFIX) \
 		--template-file log_ingestion.s3.cft.yaml \

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -46,7 +46,7 @@ deploy:
 			"TrustedIdentity=$(PARAM_TRUSTED_IDENTITY)" \
 			"IsOrganizational=$(PARAM_IS_ORGANIZATIONAL)" \
 			"OrganizationalUnitIDs=$(PARAM_ORGANIZATIONAL_UNIT_IDS)" \
-			"ARNPrefix=${PARAM_ARN_PREFIX}"
+			"Partition=${PARAM_PARTITION}"
 	aws cloudformation deploy \
 		--stack-name $(STACK_NAME)-LogIngestion-EventBridge-$(PARAM_NAME_SUFFIX) \
 		--template-file log_ingestion.events.cft.yaml \
@@ -59,7 +59,7 @@ deploy:
 			"TargetEventBusARN=$(PARAM_TARGET_EVENT_BUS_ARN)" \
 			"IsOrganizational=$(PARAM_IS_ORGANIZATIONAL)" \
 			"OrganizationalUnitIDs=$(PARAM_ORGANIZATIONAL_UNIT_IDS)" \
-			"ARNPrefix=${PARAM_ARN_PREFIX}"
+			"Partition=${PARAM_PARTITION}"
 	aws cloudformation deploy \
 		--stack-name $(STACK_NAME)-LogIngestion-S3-$(PARAM_NAME_SUFFIX) \
 		--template-file log_ingestion.s3.cft.yaml \

--- a/modules/foundational.cft.yaml
+++ b/modules/foundational.cft.yaml
@@ -11,7 +11,7 @@ Metadata:
       - TrustedIdentity
       - IsOrganizational
       - OrganizationalUnitIDs
-      - ArnPrefix
+      - ARNPrefix
     ParameterLabels:
       NameSuffix:
         default: Name Suffix
@@ -23,8 +23,8 @@ Metadata:
         default: Is Organizational
       OrganizationalUnitIDs:
         default: Organizational Unit IDs
-      ArnPrefix:
-        default: Arn Prefix
+      ARNPrefix:
+        default: ARN Prefix
 Parameters:
   NameSuffix:
     Type: String
@@ -48,7 +48,7 @@ Parameters:
   OrganizationalUnitIDs:
     Type: CommaDelimitedList
     Description: Comma separated list of organizational unit IDs to deploy
-  ArnPrefix:
+  ARNPrefix:
     Type: String
     Description: ARN prefix for the resources based on your account or organization partition
     Default: 'arn:aws'
@@ -75,7 +75,7 @@ Resources:
               sts:ExternalId:
                 Ref: ExternalID
       ManagedPolicyArns:
-      - !Sub ${ArnPrefix}:iam::aws:policy/SecurityAudit
+      - !Sub ${ARNPrefix}:iam::aws:policy/SecurityAudit
       Policies:
       - PolicyName: !Sub sysdig-secure-posture-${NameSuffix}
         PolicyDocument:
@@ -89,8 +89,8 @@ Resources:
             - waf-regional:ListRules
             - waf-regional:ListRuleGroups
             Resource:
-            - !Sub ${ArnPrefix}:waf-regional:*:*:rule/*
-            - !Sub ${ArnPrefix}:waf-regional:*:*:rulegroup/*
+            - !Sub ${ARNPrefix}:waf-regional:*:*:rule/*
+            - !Sub ${ARNPrefix}:waf-regional:*:*:rulegroup/*
           - Effect: Allow
             Action: macie2:ListClassificationJobs
             Resource: '*'
@@ -121,7 +121,7 @@ Resources:
       ManagedPolicyArns:
         Fn::If:
         - IsOrganizational
-        - - !Sub ${ArnPrefix}:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+        - - !Sub ${ARNPrefix}:iam::aws:policy/AWSOrganizationsReadOnlyAccess
         - - !Ref AWS::NoValue
       Policies:
       - PolicyName: !Sub sysdig-secure-onboarding-${NameSuffix}
@@ -161,9 +161,9 @@ Resources:
       - ParameterKey: ExternalID
         ParameterValue:
           Ref: ExternalID
-      - ParameterKey: ArnPrefix
+      - ParameterKey: ARNPrefix
         ParameterValue:
-          Ref: ArnPrefix
+          Ref: ARNPrefix
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -185,7 +185,7 @@ Resources:
           ExternalID:
             Type: String
             Description: external ID
-          ArnPrefix:
+          ARNPrefix:
             Type: String
             Description: ARN prefix for the resources based on your account or organization partition
 
@@ -205,7 +205,7 @@ Resources:
                     StringEquals:
                       sts:ExternalId: !Ref ExternalID
               ManagedPolicyArns:
-              - !Sub ${ArnPrefix}:iam::aws:policy/SecurityAudit
+              - !Sub ${ARNPrefix}:iam::aws:policy/SecurityAudit
               Policies:
               - PolicyName: !Sub sysdig-secure-posture-${NameSuffix}
                 PolicyDocument:
@@ -219,8 +219,8 @@ Resources:
                     - "waf-regional:ListRules"
                     - "waf-regional:ListRuleGroups"
                     Resource:
-                    - !Sub ${ArnPrefix}:waf-regional:*:*:rule/*
-                    - !Sub ${ArnPrefix}:waf-regional:*:*:rulegroup/*
+                    - !Sub ${ARNPrefix}:waf-regional:*:*:rule/*
+                    - !Sub ${ARNPrefix}:waf-regional:*:*:rulegroup/*
                   - Effect: "Allow"
                     Action: "macie2:ListClassificationJobs"
                     Resource: "*"

--- a/modules/foundational.cft.yaml
+++ b/modules/foundational.cft.yaml
@@ -11,6 +11,7 @@ Metadata:
       - TrustedIdentity
       - IsOrganizational
       - OrganizationalUnitIDs
+      - ArnPrefix
     ParameterLabels:
       NameSuffix:
         default: Name Suffix
@@ -22,6 +23,8 @@ Metadata:
         default: Is Organizational
       OrganizationalUnitIDs:
         default: Organizational Unit IDs
+      ArnPrefix:
+        default: Arn Prefix
 Parameters:
   NameSuffix:
     Type: String
@@ -45,6 +48,10 @@ Parameters:
   OrganizationalUnitIDs:
     Type: CommaDelimitedList
     Description: Comma separated list of organizational unit IDs to deploy
+  ArnPrefix:
+    Type: String
+    Description: ARN prefix for the resources based on your account or organization partition
+    Default: 'arn:aws'
 Conditions:
   IsOrganizational:
     Fn::Equals:
@@ -68,7 +75,7 @@ Resources:
               sts:ExternalId:
                 Ref: ExternalID
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/SecurityAudit
+      - !Sub ${ArnPrefix}:iam::aws:policy/SecurityAudit
       Policies:
       - PolicyName: !Sub sysdig-secure-posture-${NameSuffix}
         PolicyDocument:
@@ -82,8 +89,8 @@ Resources:
             - waf-regional:ListRules
             - waf-regional:ListRuleGroups
             Resource:
-            - arn:aws:waf-regional:*:*:rule/*
-            - arn:aws:waf-regional:*:*:rulegroup/*
+            - !Sub ${ArnPrefix}:waf-regional:*:*:rule/*
+            - !Sub ${ArnPrefix}:waf-regional:*:*:rulegroup/*
           - Effect: Allow
             Action: macie2:ListClassificationJobs
             Resource: '*'
@@ -114,9 +121,18 @@ Resources:
       ManagedPolicyArns:
         Fn::If:
         - IsOrganizational
-        - - arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess
-          - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
-        - - arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess
+        - - !Sub ${ArnPrefix}:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+        - - !Ref AWS::NoValue
+      Policies:
+      - PolicyName: !Sub sysdig-secure-onboarding-${NameSuffix}
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - account:Get*
+            - account:List*
+            Resource: '*'
   OrganizationStackSet:
     Type: AWS::CloudFormation::StackSet
     Condition: IsOrganizational
@@ -145,6 +161,9 @@ Resources:
       - ParameterKey: ExternalID
         ParameterValue:
           Ref: ExternalID
+      - ParameterKey: ArnPrefix
+        ParameterValue:
+          Ref: ArnPrefix
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -166,6 +185,9 @@ Resources:
           ExternalID:
             Type: String
             Description: external ID
+          ArnPrefix:
+            Type: String
+            Description: ARN prefix for the resources based on your account or organization partition
 
         Resources:
           ConfigPostureRole:
@@ -183,7 +205,7 @@ Resources:
                     StringEquals:
                       sts:ExternalId: !Ref ExternalID
               ManagedPolicyArns:
-              - arn:aws:iam::aws:policy/SecurityAudit
+              - !Sub ${ArnPrefix}:iam::aws:policy/SecurityAudit
               Policies:
               - PolicyName: !Sub sysdig-secure-posture-${NameSuffix}
                 PolicyDocument:
@@ -197,8 +219,8 @@ Resources:
                     - "waf-regional:ListRules"
                     - "waf-regional:ListRuleGroups"
                     Resource:
-                    - "arn:aws:waf-regional:*:*:rule/*"
-                    - "arn:aws:waf-regional:*:*:rulegroup/*"
+                    - !Sub ${ArnPrefix}:waf-regional:*:*:rule/*
+                    - !Sub ${ArnPrefix}:waf-regional:*:*:rulegroup/*
                   - Effect: "Allow"
                     Action: "macie2:ListClassificationJobs"
                     Resource: "*"
@@ -224,8 +246,16 @@ Resources:
                   Condition:
                     StringEquals:
                       sts:ExternalId: !Ref ExternalID
-              ManagedPolicyArns:
-                - arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess
+              Policies:
+              - PolicyName: !Sub sysdig-secure-onboarding-${NameSuffix}
+                PolicyDocument:
+                  Version: '2012-10-17'
+                  Statement:
+                  - Effect: Allow
+                    Action:
+                    - account:Get*
+                    - account:List*
+                    Resource: '*'
 
 Outputs:
   ConfigPostureRoleARN:

--- a/modules/foundational.cft.yaml
+++ b/modules/foundational.cft.yaml
@@ -11,7 +11,7 @@ Metadata:
       - TrustedIdentity
       - IsOrganizational
       - OrganizationalUnitIDs
-      - ARNPrefix
+      - Partition
     ParameterLabels:
       NameSuffix:
         default: Name Suffix
@@ -23,8 +23,8 @@ Metadata:
         default: Is Organizational
       OrganizationalUnitIDs:
         default: Organizational Unit IDs
-      ARNPrefix:
-        default: ARN Prefix
+      Partition:
+        default: AWS Partition
 Parameters:
   NameSuffix:
     Type: String
@@ -48,10 +48,10 @@ Parameters:
   OrganizationalUnitIDs:
     Type: CommaDelimitedList
     Description: Comma separated list of organizational unit IDs to deploy
-  ARNPrefix:
+  Partition:
     Type: String
-    Description: ARN prefix for the resources based on your account or organization partition
-    Default: 'arn:aws'
+    Description: AWS Partition of your account or organization to create resources in
+    Default: 'aws'
 Conditions:
   IsOrganizational:
     Fn::Equals:
@@ -75,7 +75,7 @@ Resources:
               sts:ExternalId:
                 Ref: ExternalID
       ManagedPolicyArns:
-      - !Sub ${ARNPrefix}:iam::aws:policy/SecurityAudit
+      - !Sub arn:${Partition}:iam::aws:policy/SecurityAudit
       Policies:
       - PolicyName: !Sub sysdig-secure-posture-${NameSuffix}
         PolicyDocument:
@@ -89,8 +89,8 @@ Resources:
             - waf-regional:ListRules
             - waf-regional:ListRuleGroups
             Resource:
-            - !Sub ${ARNPrefix}:waf-regional:*:*:rule/*
-            - !Sub ${ARNPrefix}:waf-regional:*:*:rulegroup/*
+            - !Sub arn:${Partition}:waf-regional:*:*:rule/*
+            - !Sub arn:${Partition}:waf-regional:*:*:rulegroup/*
           - Effect: Allow
             Action: macie2:ListClassificationJobs
             Resource: '*'
@@ -121,7 +121,7 @@ Resources:
       ManagedPolicyArns:
         Fn::If:
         - IsOrganizational
-        - - !Sub ${ARNPrefix}:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+        - - !Sub arn:${Partition}:iam::aws:policy/AWSOrganizationsReadOnlyAccess
         - - !Ref AWS::NoValue
       Policies:
       - PolicyName: !Sub sysdig-secure-onboarding-${NameSuffix}
@@ -161,9 +161,9 @@ Resources:
       - ParameterKey: ExternalID
         ParameterValue:
           Ref: ExternalID
-      - ParameterKey: ARNPrefix
+      - ParameterKey: Partition
         ParameterValue:
-          Ref: ARNPrefix
+          Ref: Partition
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -185,9 +185,9 @@ Resources:
           ExternalID:
             Type: String
             Description: external ID
-          ARNPrefix:
+          Partition:
             Type: String
-            Description: ARN prefix for the resources based on your account or organization partition
+            Description: AWS Partition of your account or organization to create resources in
 
         Resources:
           ConfigPostureRole:
@@ -205,7 +205,7 @@ Resources:
                     StringEquals:
                       sts:ExternalId: !Ref ExternalID
               ManagedPolicyArns:
-              - !Sub ${ARNPrefix}:iam::aws:policy/SecurityAudit
+              - !Sub arn:${Partition}:iam::aws:policy/SecurityAudit
               Policies:
               - PolicyName: !Sub sysdig-secure-posture-${NameSuffix}
                 PolicyDocument:
@@ -219,8 +219,8 @@ Resources:
                     - "waf-regional:ListRules"
                     - "waf-regional:ListRuleGroups"
                     Resource:
-                    - !Sub ${ARNPrefix}:waf-regional:*:*:rule/*
-                    - !Sub ${ARNPrefix}:waf-regional:*:*:rulegroup/*
+                    - !Sub arn:${Partition}:waf-regional:*:*:rule/*
+                    - !Sub arn:${Partition}:waf-regional:*:*:rulegroup/*
                   - Effect: "Allow"
                     Action: "macie2:ListClassificationJobs"
                     Resource: "*"

--- a/modules/log_ingestion.events.cft.yaml
+++ b/modules/log_ingestion.events.cft.yaml
@@ -15,7 +15,7 @@ Metadata:
       - RuleEventPattern
       - IsOrganizational
       - OrganizationalUnitIDs
-      - ARNPrefix
+      - Partition
     ParameterLabels:  
       NameSuffix:
         default: Name Suffix
@@ -35,8 +35,8 @@ Metadata:
         default: Is Organizational
       OrganizationalUnitIDs:
         default: Organizational Unit IDs
-      ARNPrefix:
-        default: ARN Prefix
+      Partition:
+        default: AWS Partition
 Parameters:
   NameSuffix:
     Type: String
@@ -96,10 +96,10 @@ Parameters:
     AllowedValues:
     - 'true'
     - 'false'
-  ARNPrefix:
+  Partition:
     Type: String
-    Description: ARN prefix for the resources based on your account or organization partition
-    Default: 'arn:aws'
+    Description: AWS Partition of your account or organization to create resources in
+    Default: 'aws'
 Conditions:
   IsOrganizational:
     Fn::Equals:
@@ -127,7 +127,7 @@ Resources:
             Action:
             - sts:AssumeRole
             Resource:
-            - !Sub ${ARNPrefix}:iam:::role/sysdig-secure-events-stackset-execution-${NameSuffix}
+            - !Sub arn:${Partition}:iam:::role/sysdig-secure-events-stackset-execution-${NameSuffix}
   ExecutionRole:
     Type: AWS::IAM::Role   
     Properties:
@@ -142,8 +142,8 @@ Resources:
           Action:
           - sts:AssumeRole
       ManagedPolicyArns:
-      - !Sub ${ARNPrefix}:iam::aws:policy/AmazonEventBridgeFullAccess
-      - !Sub ${ARNPrefix}:iam::aws:policy/AWSCloudFormationFullAccess
+      - !Sub arn:${Partition}:iam::aws:policy/AmazonEventBridgeFullAccess
+      - !Sub arn:${Partition}:iam::aws:policy/AWSCloudFormationFullAccess
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
@@ -175,7 +175,7 @@ Resources:
             - "events:DescribeRule"
             - "events:ListTargetsByRule"
             Resource:
-            - !Sub ${ARNPrefix}:events:*:*:rule/sysdig-secure-events-${NameSuffix}
+            - !Sub arn:${Partition}:events:*:*:rule/sysdig-secure-events-${NameSuffix}
   EventBridgeRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Metadata:
@@ -211,8 +211,8 @@ Resources:
           ParameterValue: !Ref RuleState
         - ParameterKey: RuleEventPattern
           ParameterValue: !Ref RuleEventPattern
-        - ParameterKey: ARNPrefix
-          ParameterValue: !Ref ARNPrefix
+        - ParameterKey: Partition
+          ParameterValue: !Ref Partition
       StackInstancesGroup:
         - DeploymentTargets:
             Accounts: 
@@ -239,9 +239,9 @@ Resources:
           RuleEventPattern:
             Type: String
             Description: JSON pattern for the EventBridge rule's event pattern
-          ARNPrefix:
+          Partition:
             Type: String
-            Description: ARN prefix for the resources based on your account or organization partition
+            Description: AWS Partition of your account or organization to create resources in
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -253,7 +253,7 @@ Resources:
               Targets:
                 - Id: !Ref Name
                   Arn: !Sub ${TargetEventBusARN}
-                  RoleArn: !Sub ${ARNPrefix}:iam::${AWS::AccountId}:role/${Name}
+                  RoleArn: !Sub arn:${Partition}:iam::${AWS::AccountId}:role/${Name}
   OrganizationRoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Condition: IsOrganizational
@@ -281,8 +281,8 @@ Resources:
         ParameterValue: !Ref ExternalID
       - ParameterKey: TargetEventBusARN
         ParameterValue: !Ref TargetEventBusARN
-      - ParameterKey: ARNPrefix
-        ParameterValue: !Ref ARNPrefix
+      - ParameterKey: Partition
+        ParameterValue: !Ref Partition
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -303,9 +303,9 @@ Resources:
           TargetEventBusARN:
             Type: String
             Description: The destination in Sysdig's AWS account where your events are sent
-          ARNPrefix:
+          Partition:
             Type: String
-            Description: ARN prefix for the resources based on your account or organization partition
+            Description: AWS Partition of your account or organization to create resources in
         Resources:
           EventBridgeRole:
             Type: AWS::IAM::Role
@@ -338,7 +338,7 @@ Resources:
                     - "events:DescribeRule"
                     - "events:ListTargetsByRule"
                     Resource:
-                    - !Sub ${ARNPrefix}:events:*:*:rule/${Name}
+                    - !Sub arn:${Partition}:events:*:*:rule/${Name}
   OrganizationRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Condition: IsOrganizational
@@ -369,8 +369,8 @@ Resources:
         ParameterValue: !Ref RuleState
       - ParameterKey: RuleEventPattern
         ParameterValue: !Ref RuleEventPattern
-      - ParameterKey: ARNPrefix
-        ParameterValue: !Ref ARNPrefix
+      - ParameterKey: Partition
+        ParameterValue: !Ref Partition
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -396,9 +396,9 @@ Resources:
           RuleEventPattern:
             Type: String
             Description: JSON pattern for the EventBridge rule's event pattern
-          ARNPrefix:
+          Partition:
             Type: String
-            Description: ARN prefix for the resources based on your account or organization partition
+            Description: AWS Partition of your account or organization to create resources in
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -410,7 +410,7 @@ Resources:
               Targets:
                 - Id: !Ref Name
                   Arn: !Ref TargetEventBusARN
-                  RoleArn: !Sub "${ARNPrefix}:iam::${AWS::AccountId}:role/${Name}"
+                  RoleArn: !Sub "arn:${Partition}:iam::${AWS::AccountId}:role/${Name}"
 Outputs:
   EventBridgeRoleARN:
     Description: Sysdig Secure EventBridge Role ARN

--- a/modules/log_ingestion.events.cft.yaml
+++ b/modules/log_ingestion.events.cft.yaml
@@ -15,25 +15,28 @@ Metadata:
       - RuleEventPattern
       - IsOrganizational
       - OrganizationalUnitIDs
+      - ArnPrefix
     ParameterLabels:  
       NameSuffix:
         default: Name Suffix
       ExternalID:
-        default: "External ID"
+        default: External ID
       TrustedIdentity:
-        default: "Trusted Identity"
+        default: Trusted Identity
       TargetEventBusARN:
-        default: "Target Event Bus"
+        default: Target Event Bus
       Regions:
-        default: "Instrumented Regions"
+        default: Instrumented Regions
       RuleState:
-        default: "EventBridge Rule state"
+        default: EventBridge Rule state
       RuleEventPattern:
-        default: "EventBridge Rule event pattern"
+        default: EventBridge Rule event pattern
       IsOrganizational:
         default: Is Organizational
       OrganizationalUnitIDs:
-        default: "Organizational Unit IDs"
+        default: Organizational Unit IDs
+      ArnPrefix:
+        default: Arn Prefix
 Parameters:
   NameSuffix:
     Type: String
@@ -93,6 +96,10 @@ Parameters:
     AllowedValues:
     - 'true'
     - 'false'
+  ArnPrefix:
+    Type: String
+    Description: ARN prefix for the resources based on your account or organization partition
+    Default: 'arn:aws'
 Conditions:
   IsOrganizational:
     Fn::Equals:
@@ -120,7 +127,7 @@ Resources:
             Action:
             - sts:AssumeRole
             Resource:
-            - !Sub arn:aws:iam:::role/sysdig-secure-events-stackset-execution-${NameSuffix}
+            - !Sub ${ArnPrefix}:iam:::role/sysdig-secure-events-stackset-execution-${NameSuffix}
   ExecutionRole:
     Type: AWS::IAM::Role   
     Properties:
@@ -135,8 +142,8 @@ Resources:
           Action:
           - sts:AssumeRole
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess
-      - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+      - !Sub ${ArnPrefix}:iam::aws:policy/AmazonEventBridgeFullAccess
+      - !Sub ${ArnPrefix}:iam::aws:policy/AWSCloudFormationFullAccess
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
@@ -168,7 +175,7 @@ Resources:
             - "events:DescribeRule"
             - "events:ListTargetsByRule"
             Resource:
-            - !Sub arn:aws:events:*:*:rule/sysdig-secure-events-${NameSuffix}
+            - !Sub ${ArnPrefix}:events:*:*:rule/sysdig-secure-events-${NameSuffix}
   EventBridgeRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Metadata:
@@ -203,7 +210,9 @@ Resources:
         - ParameterKey: RuleState
           ParameterValue: !Ref RuleState
         - ParameterKey: RuleEventPattern
-          ParameterValue: !Ref RuleEventPattern                     
+          ParameterValue: !Ref RuleEventPattern
+        - ParameterKey: ArnPrefix
+          ParameterValue: !Ref ArnPrefix
       StackInstancesGroup:
         - DeploymentTargets:
             Accounts: 
@@ -230,6 +239,9 @@ Resources:
           RuleEventPattern:
             Type: String
             Description: JSON pattern for the EventBridge rule's event pattern
+          ArnPrefix:
+            Type: String
+            Description: ARN prefix for the resources based on your account or organization partition
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -241,7 +253,7 @@ Resources:
               Targets:
                 - Id: !Ref Name
                   Arn: !Sub ${TargetEventBusARN}
-                  RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/${Name}
+                  RoleArn: !Sub ${ArnPrefix}:iam::${AWS::AccountId}:role/${Name}
   OrganizationRoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Condition: IsOrganizational
@@ -269,6 +281,8 @@ Resources:
         ParameterValue: !Ref ExternalID
       - ParameterKey: TargetEventBusARN
         ParameterValue: !Ref TargetEventBusARN
+      - ParameterKey: ArnPrefix
+        ParameterValue: !Ref ArnPrefix
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -288,7 +302,10 @@ Resources:
             Description: A unique identifier used to create and reference resources
           TargetEventBusARN:
             Type: String
-            Description: The destination in Sysdig's AWS account where your events are sent                        
+            Description: The destination in Sysdig's AWS account where your events are sent
+          ArnPrefix:
+            Type: String
+            Description: ARN prefix for the resources based on your account or organization partition
         Resources:
           EventBridgeRole:
             Type: AWS::IAM::Role
@@ -321,7 +338,7 @@ Resources:
                     - "events:DescribeRule"
                     - "events:ListTargetsByRule"
                     Resource:
-                    - !Sub arn:aws:events:*:*:rule/${Name}
+                    - !Sub ${ArnPrefix}:events:*:*:rule/${Name}
   OrganizationRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Condition: IsOrganizational
@@ -352,6 +369,8 @@ Resources:
         ParameterValue: !Ref RuleState
       - ParameterKey: RuleEventPattern
         ParameterValue: !Ref RuleEventPattern
+      - ParameterKey: ArnPrefix
+        ParameterValue: !Ref ArnPrefix
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -377,6 +396,9 @@ Resources:
           RuleEventPattern:
             Type: String
             Description: JSON pattern for the EventBridge rule's event pattern
+          ArnPrefix:
+            Type: String
+            Description: ARN prefix for the resources based on your account or organization partition
         Resources:           
           EventBridgeRule:
             Type: "AWS::Events::Rule"
@@ -388,7 +410,7 @@ Resources:
               Targets:
                 - Id: !Ref Name
                   Arn: !Ref TargetEventBusARN
-                  RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${Name}"
+                  RoleArn: !Sub "${ArnPrefix}:iam::${AWS::AccountId}:role/${Name}"
 Outputs:
   EventBridgeRoleARN:
     Description: Sysdig Secure EventBridge Role ARN

--- a/modules/log_ingestion.events.cft.yaml
+++ b/modules/log_ingestion.events.cft.yaml
@@ -15,7 +15,7 @@ Metadata:
       - RuleEventPattern
       - IsOrganizational
       - OrganizationalUnitIDs
-      - ArnPrefix
+      - ARNPrefix
     ParameterLabels:  
       NameSuffix:
         default: Name Suffix
@@ -35,8 +35,8 @@ Metadata:
         default: Is Organizational
       OrganizationalUnitIDs:
         default: Organizational Unit IDs
-      ArnPrefix:
-        default: Arn Prefix
+      ARNPrefix:
+        default: ARN Prefix
 Parameters:
   NameSuffix:
     Type: String
@@ -96,7 +96,7 @@ Parameters:
     AllowedValues:
     - 'true'
     - 'false'
-  ArnPrefix:
+  ARNPrefix:
     Type: String
     Description: ARN prefix for the resources based on your account or organization partition
     Default: 'arn:aws'
@@ -127,7 +127,7 @@ Resources:
             Action:
             - sts:AssumeRole
             Resource:
-            - !Sub ${ArnPrefix}:iam:::role/sysdig-secure-events-stackset-execution-${NameSuffix}
+            - !Sub ${ARNPrefix}:iam:::role/sysdig-secure-events-stackset-execution-${NameSuffix}
   ExecutionRole:
     Type: AWS::IAM::Role   
     Properties:
@@ -142,8 +142,8 @@ Resources:
           Action:
           - sts:AssumeRole
       ManagedPolicyArns:
-      - !Sub ${ArnPrefix}:iam::aws:policy/AmazonEventBridgeFullAccess
-      - !Sub ${ArnPrefix}:iam::aws:policy/AWSCloudFormationFullAccess
+      - !Sub ${ARNPrefix}:iam::aws:policy/AmazonEventBridgeFullAccess
+      - !Sub ${ARNPrefix}:iam::aws:policy/AWSCloudFormationFullAccess
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
@@ -175,7 +175,7 @@ Resources:
             - "events:DescribeRule"
             - "events:ListTargetsByRule"
             Resource:
-            - !Sub ${ArnPrefix}:events:*:*:rule/sysdig-secure-events-${NameSuffix}
+            - !Sub ${ARNPrefix}:events:*:*:rule/sysdig-secure-events-${NameSuffix}
   EventBridgeRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Metadata:
@@ -211,8 +211,8 @@ Resources:
           ParameterValue: !Ref RuleState
         - ParameterKey: RuleEventPattern
           ParameterValue: !Ref RuleEventPattern
-        - ParameterKey: ArnPrefix
-          ParameterValue: !Ref ArnPrefix
+        - ParameterKey: ARNPrefix
+          ParameterValue: !Ref ARNPrefix
       StackInstancesGroup:
         - DeploymentTargets:
             Accounts: 
@@ -239,7 +239,7 @@ Resources:
           RuleEventPattern:
             Type: String
             Description: JSON pattern for the EventBridge rule's event pattern
-          ArnPrefix:
+          ARNPrefix:
             Type: String
             Description: ARN prefix for the resources based on your account or organization partition
         Resources:           
@@ -253,7 +253,7 @@ Resources:
               Targets:
                 - Id: !Ref Name
                   Arn: !Sub ${TargetEventBusARN}
-                  RoleArn: !Sub ${ArnPrefix}:iam::${AWS::AccountId}:role/${Name}
+                  RoleArn: !Sub ${ARNPrefix}:iam::${AWS::AccountId}:role/${Name}
   OrganizationRoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Condition: IsOrganizational
@@ -281,8 +281,8 @@ Resources:
         ParameterValue: !Ref ExternalID
       - ParameterKey: TargetEventBusARN
         ParameterValue: !Ref TargetEventBusARN
-      - ParameterKey: ArnPrefix
-        ParameterValue: !Ref ArnPrefix
+      - ParameterKey: ARNPrefix
+        ParameterValue: !Ref ARNPrefix
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -303,7 +303,7 @@ Resources:
           TargetEventBusARN:
             Type: String
             Description: The destination in Sysdig's AWS account where your events are sent
-          ArnPrefix:
+          ARNPrefix:
             Type: String
             Description: ARN prefix for the resources based on your account or organization partition
         Resources:
@@ -338,7 +338,7 @@ Resources:
                     - "events:DescribeRule"
                     - "events:ListTargetsByRule"
                     Resource:
-                    - !Sub ${ArnPrefix}:events:*:*:rule/${Name}
+                    - !Sub ${ARNPrefix}:events:*:*:rule/${Name}
   OrganizationRuleStackSet:
     Type: AWS::CloudFormation::StackSet
     Condition: IsOrganizational
@@ -369,8 +369,8 @@ Resources:
         ParameterValue: !Ref RuleState
       - ParameterKey: RuleEventPattern
         ParameterValue: !Ref RuleEventPattern
-      - ParameterKey: ArnPrefix
-        ParameterValue: !Ref ArnPrefix
+      - ParameterKey: ARNPrefix
+        ParameterValue: !Ref ARNPrefix
       StackInstancesGroup:
       - DeploymentTargets:
           OrganizationalUnitIds: !Ref OrganizationalUnitIDs
@@ -396,7 +396,7 @@ Resources:
           RuleEventPattern:
             Type: String
             Description: JSON pattern for the EventBridge rule's event pattern
-          ArnPrefix:
+          ARNPrefix:
             Type: String
             Description: ARN prefix for the resources based on your account or organization partition
         Resources:           
@@ -410,7 +410,7 @@ Resources:
               Targets:
                 - Id: !Ref Name
                   Arn: !Ref TargetEventBusARN
-                  RoleArn: !Sub "${ArnPrefix}:iam::${AWS::AccountId}:role/${Name}"
+                  RoleArn: !Sub "${ARNPrefix}:iam::${AWS::AccountId}:role/${Name}"
 Outputs:
   EventBridgeRoleARN:
     Description: Sysdig Secure EventBridge Role ARN

--- a/modules/log_ingestion.s3.cft.yaml
+++ b/modules/log_ingestion.s3.cft.yaml
@@ -20,11 +20,11 @@ Metadata:
       NameSuffix:
         default: Name Suffix
       ExternalID:
-        default: "External ID"
+        default: External ID
       TrustedIdentity:
-        default: "Trusted Identity"
+        default: Trusted Identity
       BucketARN:
-        default: "Bucket ARN"
+        default: Bucket ARN
 
 Parameters:
   NameSuffix:


### PR DESCRIPTION
Change summary:
-------------------
- Added support to install govcloud single account and org in foundational template.
- Added same support in log_ingestion event-bridge template.
- For log_ingestion s3, no changes required to the template. Added minor nits.

Testing done:
----------------
With the UI PR changes was able to test below,

Single AWS Govcloud account,
- Foundational onboarding - ✅ 
- CDR install with EB - Unsupported (CFT stack creation & BE block this as expected) - ✅ 
- CDR install with S3 -  ✅ 

AWS Govcloud Org,
- Foundational onboarding -  ✅
- CDR install with EB - Unsupported (CFT stack creation & BE block this as expected) -  ✅ 
- CDR install with S3 - NA