### PR TITLE
fix(vm-workload-scanning): Fixing CFT for Managament Account for Workload Scanning [SSPROD-52797]

### DIFF
--- a/modules/vm_workload_scanning.cft.yaml
+++ b/modules/vm_workload_scanning.cft.yaml
@@ -66,7 +66,7 @@ Conditions:
       - Ref: IsOrganizational
       - 'false'
   IsLambdaEnabled:
-    - Fn::Equals:
+    Fn::Equals:
       - Ref: LambdaScanningEnabled
       - 'true'
 

--- a/modules/vm_workload_scanning.cft.yaml
+++ b/modules/vm_workload_scanning.cft.yaml
@@ -61,10 +61,6 @@ Conditions:
     Fn::Equals:
       - Ref: IsOrganizational
       - 'true'
-  IsNotOrganizational:
-    Fn::Equals:
-      - Ref: IsOrganizational
-      - 'false'
   IsLambdaEnabled:
     Fn::Equals:
       - Ref: LambdaScanningEnabled

--- a/modules/vm_workload_scanning.cft.yaml
+++ b/modules/vm_workload_scanning.cft.yaml
@@ -73,11 +73,15 @@ Conditions:
       - Fn::Equals:
         - Ref: LambdaScanningEnabled
         - 'true'
+  IsLambdaEnabled:
+    Fn::And:
+      - Fn::Equals:
+          - Ref: LambdaScanningEnabled
+          - 'true'
 
 Resources:
   ScanningRole:
     Type: AWS::IAM::Role
-    Condition: IsNotOrganizational
     Properties:
       RoleName: !Sub sysdig-vm-workload-scanning-${NameSuffix}
       AssumeRolePolicyDocument:
@@ -94,7 +98,6 @@ Resources:
                   Ref: ExternalID
   ECRPolicy:
     Type: AWS::IAM::Policy
-    Condition: IsNotOrganizational
     Properties:
       PolicyName: !Sub sysdig-vm-workload-scanning-${NameSuffix}-ecr
       Roles:
@@ -112,7 +115,7 @@ Resources:
             Resource: '*'
   LambdaPolicy:
     Type: AWS::IAM::Policy
-    Condition: IsNotOrganizationalAndLambdaEnabled
+    Condition: IsLambdaEnabled
     Properties:
       PolicyName: !Sub sysdig-vm-workload-scanning-${NameSuffix}-lambda
       Roles:

--- a/modules/vm_workload_scanning.cft.yaml
+++ b/modules/vm_workload_scanning.cft.yaml
@@ -66,10 +66,9 @@ Conditions:
       - Ref: IsOrganizational
       - 'false'
   IsLambdaEnabled:
-    Fn::And:
-      - Fn::Equals:
-          - Ref: LambdaScanningEnabled
-          - 'true'
+    - Fn::Equals:
+      - Ref: LambdaScanningEnabled
+      - 'true'
 
 Resources:
   ScanningRole:

--- a/modules/vm_workload_scanning.cft.yaml
+++ b/modules/vm_workload_scanning.cft.yaml
@@ -65,14 +65,6 @@ Conditions:
     Fn::Equals:
       - Ref: IsOrganizational
       - 'false'
-  IsNotOrganizationalAndLambdaEnabled:
-    Fn::And:
-      - Fn::Equals:
-        - Ref: IsOrganizational
-        - 'false'
-      - Fn::Equals:
-        - Ref: LambdaScanningEnabled
-        - 'true'
   IsLambdaEnabled:
     Fn::And:
       - Fn::Equals:


### PR DESCRIPTION
https://sysdigcloud.slack.com/archives/CMCPMSQ8Y/p1738853886784009

Hi team, Covantis POV here. We onboarded AWS org via CFT CSPM+CDR/CIEM+WorkloadScanning
I think the CFT template we use for WorkloadScanning does not create the required role sysdig-vm-workload-scanning-xxxxx in the management account (1st screenshot). I was able to replicate that in our lab aws org, I don't see the role in the list of resources created by the stack (2nd screenshot), just the stackset that will be used for sub-accounts.
Can you please check? [cc 
[@Stefan Trimborn](https://sysdigcloud.slack.com/team/U036WTW25AT)
] (edited)