### PR TITLE
fix(aws): template for eb and s3

### DIFF
--- a/modules/log_ingestion.events.cft.yaml
+++ b/modules/log_ingestion.events.cft.yaml
@@ -4,6 +4,10 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
+        default: ""
+      Parameters:
+      - RuleEventPattern
+    - Label:
         default: "Sysdig Settings (Do not change)"
       Parameters:
       - NameSuffix
@@ -12,7 +16,6 @@ Metadata:
       - TargetEventBusARN
       - Regions
       - RuleState
-      - RuleEventPattern
       - IsOrganizational
       - OrganizationalUnitIDs
       - Partition


### PR DESCRIPTION
on AWS EB CFT templates, split sysdig required settings and user input parameters

![image](https://github.com/user-attachments/assets/bb86960c-5c9d-451e-b747-4965bb4e01d5)
