### PR TITLE
response-actions: PackageDownloaderLogGroup deletion policy leaving unwanted resources

### DIFF
--- a/modules/response_actions.cft.yaml
+++ b/modules/response_actions.cft.yaml
@@ -733,7 +733,6 @@ Resources:
 
           PackageDownloaderLogGroup:
             Type: AWS::Logs::LogGroup
-            DeletionPolicy: Retain
             Properties:
               LogGroupName: !Sub '/aws/lambda/${ResourceName}-package-downloader'
               RetentionInDays: 7


### PR DESCRIPTION
## Issue

In `modules/response_actions.cft.yaml`, `PackageDownloaderLogGroup` is created with `DeletionPolicy: Retain`. It was the only one of the eight Lambda log groups configured this way — the other seven use CloudFormation's default (`Delete`).

If an account/region is offboarded and later onboarded again, the retained log group (`/aws/lambda/${ResourceName}-package-downloader`) survives the stackset deletion, so re-onboarding fails because the resource already exists.

## Fix

Remove `DeletionPolicy: Retain` from `PackageDownloaderLogGroup`, aligning it with the other log groups so it is deleted on offboarding and can be recreated on re-onboarding.